### PR TITLE
fix pkg name

### DIFF
--- a/di-si-zhang-zhuo-mian-an-zhuang/di-wu-jie-an-zhuang-xfce.md
+++ b/di-si-zhang-zhuo-mian-an-zhuang/di-wu-jie-an-zhuang-xfce.md
@@ -2,7 +2,7 @@
 
 ## 安装 xfce4
 
-通过 pkg 安装 `# pkg install xorg lightdm lightdm-gtk-greeter xfce4`
+通过 pkg 安装 `# pkg install xorg lightdm lightdm-gtk-greeter xfce`
 
 或
 


### PR DESCRIPTION
Ref: https://docs.freebsd.org/en/books/handbook/x11/
The xfce4 pkg named `xfce` instead of `xfce4`