### PR TITLE
更新 fcitx5-gtk

### DIFF
--- a/di-5-zhang-shu-ru-fa-ji-chang-yong-ruan-jian/di-5.1-jie-fcitx-shu-ru-fa-kuang-jia.md
+++ b/di-5-zhang-shu-ru-fa-ji-chang-yong-ruan-jian/di-5.1-jie-fcitx-shu-ru-fa-kuang-jia.md
@@ -40,7 +40,7 @@ setenv LC_ALL zh_CN.UTF-8
 
 fcitx 5 相比前一代，增加了对 Wayland 的支持，据说更加流畅。
 
-`# pkg install fcitx5 fcitx5-qt5 fcitx5-qt6 fcitx5-gtk fcitx5-configtool zh-fcitx5-chinese-addons`
+`# pkg install fcitx5 fcitx5-qt5 fcitx5-qt6 fcitx5-gtk2 fcitx5-gtk3 fcitx5-gtk4 fcitx5-configtool zh-fcitx5-chinese-addons`
 
 也可通过 ports 安装。环境变量取决于你的窗口管理器和桌面以及 shell。经测试不支持 slim，可能是配置问题。sddm 可用。
 


### PR DESCRIPTION
我前段时间重新安装 fcitx5，根据手册安装发现 fcitx5-gtk 不可用，我查看 freshports 后了解到该软件包拆分成了针对不同版本的 gtk。

https://www.freshports.org/textproc/fcitx5-gtk/