### PR TITLE
Update di-29.5-jie-an-zhuang-hyprland.md

### DIFF
--- a/di-29-zhang-zhuo-mian-gao-ji-jin-jie/di-29.5-jie-an-zhuang-hyprland.md
+++ b/di-29-zhang-zhuo-mian-gao-ji-jin-jie/di-29.5-jie-an-zhuang-hyprland.md
@@ -7,13 +7,15 @@ Hyprland 是 Wayland 的一个合成器，支持窗口透明、模糊、圆角�
 ## 安装 Hyprland
 
 ```shell-session
-# pkg ins wayland hyprland waybar-hyprland rofi wofi qt5-base qt6-base qt5-wayland qt6-wayland xdg-desktop-portal-hyprland hyprpicker swaybg mako dbus nerd-fonts
+# pkg ins wayland hyprland waybar-hyprland rofi wofi qt5-base qt6-base qt5-wayland qt6-wayland xdg-desktop-portal-hyprland hyprpicker swaybg mako dbus nerd-fonts slurp grim swaylock
 ```
 
 - waybar 为 hyprland 的菜单栏。
 - rofi 和 wofi 是程序启动器
 - mako 用于显示通知
 - nerd-fonts 为图标字体，可以用来在配置文件中插入图案，显示在 waybar 等地方
+- slurp用来在屏幕上选区
+- grim用来捕获屏幕截图
 
 
 ## 首次启动 Hyprland
@@ -45,12 +47,12 @@ $ unzip -d ~/
 ```
 
 
-自动启动，将下行写入 `~/.xinitrc`：
+自动启动，将下行写入 `~/.zprofile`：
 
 ```
 ck-launch-session Hyprland
 ```
-
+如果默认shell是sh，应该写入~/.profile
 也可以指定配置文件 `Hyprland -c 配置文件路径`
 
 ### 配置 hyprland.conf
@@ -80,7 +82,10 @@ OR EDIT THIS ONE ACCORDING TO THE WIKI INSTRUCTIONS.
 # 壁纸
 #exec-once=swaybg -i "$HOME/Pictures/Wallpapers/2769378.jpg"
 # 任务栏
-#exec-once=waybar
+exec-once=waybar
+# swaylock
+exec-once=swayidle -w timeout 300 'swaylock'
+
 
 #
 # Please note not all available settings / options are set here.
@@ -198,6 +203,10 @@ windowrulev2 = float, title:图片查看器
 
 # See https://wiki.hyprland.org/Configuring/Keywords/ for more
 $mainMod = SUPER # 用 win 键作为 mod 键
+$shiftMod=SUPER_SHIFT
+$altMod=SUPER_ALT
+$alt=ALT
+$shift=SHIFT
 
 # Example binds, see https://wiki.hyprland.org/Configuring/Binds/ for more
 bind = $mainMod, Q, exec, kitty # 打开终端
@@ -208,6 +217,12 @@ bind = $mainMod, V, togglefloating,  # 切换为悬浮窗口，可拖动
 bind = $mainMod, R, exec, wofi --show drun # 软件启动器，类似菜单
 bind = $mainMod, P, pseudo, # dwindle
 bind = $mainMod, J, togglesplit, # dwindle
+### 截图
+$screen_file=${HOME}/screen_shot_$(date + "%Y-%m-%d_%H-%M-%S").png
+bind=$shiftMod, S, exec, grim -g "$(slurp)" - | wl-copy
+bind=, Print,      exec, grim $screen_file
+bind=$shift, Print,exec, grim -g "$(slurp)" $screen_file
+bind=$alt, Print,  exec, grim - | wl-copy
 
 # Move focus with mainMod + arrow keys
 bind = $mainMod, left, movefocus, l
@@ -726,6 +741,63 @@ window#waybar {
 
 ```
 
+###配置swaylock
+
+swaylock的配置文件在`~/.config/swaylock/config`中，以下是示例配置文件：
+```
+ignore-empty-password
+font=Fira Sans Compressed
+
+clock
+timestr=%R
+datestr=%a, %e of %B
+
+screenshots
+
+fade-in=0.2
+
+effect-blur=20x2
+#effect-greyscale
+effect-scale=0.3
+
+indicator
+indicator-radius=360
+indicator-thickness=60
+indicator-caps-lock
+
+key-hl-color=228833
+
+separator-color=00000000
+
+inside-color=00000099
+inside-clear-color=ffd20400
+inside-caps-lock-color=009ddc00
+inside-ver-color=d9d8d800
+inside-wrong-color=ee2e2400
+
+ring-color=231f20D9
+ring-clear-color=231f20D9
+ring-caps-lock-color=231f20D9
+ring-ver-color=231f20D9
+ring-wrong-color=231f20D9
+
+line-color=00000000
+line-clear-color=ffd2000
+line-caps-lock-color=009ddc00
+line-ver-color=d9d8d800
+line-wrong-color=ee2e2400
+
+text-clear-color=ffd20400
+text-ver-color=d9d8d800
+text-wrong-color=ee2e2400
+
+bs-hl-color=ee2e24FF
+#caps-lock-key-hl-color=ffd204FF
+#caps-lcok-key-hl-color=ee2e24FF
+#caps-lock-bs-hl-color=ee2e24FF
+#disable-caps-lock-text
+text-caps-lock-color=000000FF
+```
 
 
 ## 故障排除
@@ -735,3 +807,4 @@ window#waybar {
 ## 参考文献
 
 - [ArchLinux 下 Hyprland 配置指北](https://www.bilibili.com/read/cv22707313/)
+- [Hyprland的配置](https://nth233.top/posts/2023-02-26-Hyprland%E9%85%8D%E7%BD%AE)


### PR DESCRIPTION
新增的软件包，截屏和锁屏。另外我昨天新发的截图可以体现出来文章开头说的窗口透明效果，要不要考虑，换一下？
解释一下，~/.xinitrc是X的配置文件，但是这是wayland，所以是无效的。这里改成了.profile，和.zprofile。
晚饭时候我看了一下handbook，# sysctl hw.acpi.lid_switch_state=S3，是系统挂起命令，如果道长有时间，希望能帮忙测试一下命令是否有效。然后可以加进hyprland.conf里面，配置是：exec-once=swayidle -w timeout 900 'sysctl hw.acpi.lid_switch_state=S3'
这个900是秒数，也就是15分钟无操作以后，系统自动挂起到RAM。
我用KDE的时候，点击sddm的休眠，可以进入S3休眠，CPU和电源的风扇停转，USB设备有电。（FreeBSD上，SDDM不能用于Hyprland，进不去。但是据Linux用户说，Linux上可以）