### PR TITLE
fix: 修复 sddm 中文化的配置

### DIFF
--- a/di-4-zhang-zhuo-mian-an-zhuang/di-4.2-jie-an-zhuang-kde-5.md
+++ b/di-4-zhang-zhuo-mian-an-zhuang/di-4.2-jie-an-zhuang-kde-5.md
@@ -109,7 +109,7 @@ proc            /proc           procfs  rw      0       0
 
 
 ```
-# sysrc sddm_lang="zh_CN.UTF-8"
+# sysrc sddm_lang="zh_CN"
 ```
 
 <img src="../.gitbook/assets/sddmcn.png" alt="" data-size="original">


### PR DESCRIPTION
似乎是因为 sddm 更新，rc 脚本变了，不需要 `.UTF-8` 的后缀了。