### PR TITLE
移除失效链接

### DIFF
--- a/di-18-zhang-shu-mei-pai-yu-riscv/di-18.6-jie-zai-riscv-kai-fa-ban-shang-an-zhuang-openbsd.md
+++ b/di-18-zhang-shu-mei-pai-yu-riscv/di-18.6-jie-zai-riscv-kai-fa-ban-shang-an-zhuang-openbsd.md
@@ -21,7 +21,7 @@ riscv 启动与树莓派不同（树莓派都在那个 EFI 分区中），一般
 
 ## 镜像准备
 
-从 OpenBSD 官网下载 [miniroot.img 7.4](https://cdn.openbsd.org/pub/OpenBSD/7.4/riscv64/miniroot74.img)
+从 OpenBSD 官网下载 `miniroot74.img`。
 
 从 <https://marc.info/?l=openbsd-misc&m=169046816826966&q=p3> 下载 `jh7110-starfive-visionfive-2-v1.3b.dtb` 并上传到 tftp 服务器。
 

--- a/di-2-zhang-an-zhuang-freebsd/di-2.6-jie-teng-xun-yun-qing-liang-yun-ji-qi-ta-fu-wu-qi-dd-an-zhuang-freebsd.md
+++ b/di-2-zhang-an-zhuang-freebsd/di-2.6-jie-teng-xun-yun-qing-liang-yun-ji-qi-ta-fu-wu-qi-dd-an-zhuang-freebsd.md
@@ -82,7 +82,7 @@ mfsBSD 和 mfsLinux 镜像的 `root` 密码默认均是 `mfsroot`
 
 ssh 连接服务器后，使用 `kldload zfs` 加载 zfs 模块，然后运行 `bsdinstall`，在出现以下图片时，点 `Other` 输入图中的指定镜像版本（地址里有即可，你可以自己改哦）：
 
-示例：如 <https://mirrors.ustc.edu.cn/freebsd/releases/amd64/14.2-RELEASE/> 或 <https://mirrors.nju.edu.cn/freebsd/snapshots/arm64/15.0-CURRENT/>
+示例：如 <https://mirrors.ustc.edu.cn/freebsd/releases/amd64/14.2-RELEASE/> 或 <https://mirrors.nju.edu.cn/freebsd/snapshots/amd64/15.0-CURRENT/>
 
 ![腾讯云轻量云及其他服务器安装 FreeBSD](../.gitbook/assets/installBSD1.png)
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 更新了 OpenBSD 和 FreeBSD 安装文档中的链接，移除了直接 URL 引用，并修复了示例路径中的一个小错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Updated links in OpenBSD and FreeBSD installation documentation to remove direct URL references and fix a minor typo in an example path

</details>