### PR TITLE
typo

### DIFF
--- a/di-17-zhang-wang-luo-fu-wu-qi/17.10.prometheus.md
+++ b/di-17-zhang-wang-luo-fu-wu-qi/17.10.prometheus.md
@@ -410,7 +410,7 @@ echo "process_zombie $num"|curl --data-binary @- http://10.0.55.1:9091/metrics/j
 
 ## 告警
 
-prometheus 告警依赖 alertmanager 组件。这里示例以 jail_exporter 为例（安装配置较为简单，参见上文，不再说明。另需要 `/boot/loader.conf` 中写入 `kern.racct.enable=1`，以开启系统记帐功能）。
+prometheus 告警依赖 alertmanager 组件。这里示例以 jail_exporter 为例（安装配置较为简单，参见上文，不再说明。另需要 `/boot/loader.conf` 中写入 `kern.racct.enable=1`，以开启系统记账功能）。
 
 1. 安装：
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 修正了中文文档中的一个错字，将 Prometheus 告警部分中的 '记帐' 改为 '记账'。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Corrected a typo in the Chinese documentation, changing '记帐' to '记账' in the Prometheus alerting section

</details>