### PR TITLE
移除来自网络的未经验证且无用的内容

### DIFF
--- a/di-13-zhang-freebsd-te-se/di-13.4-jie-chang-yong-ruan-jian-yu-ssh-pei-zhi.md
+++ b/di-13-zhang-freebsd-te-se/di-13.4-jie-chang-yong-ruan-jian-yu-ssh-pei-zhi.md
@@ -163,36 +163,6 @@ PasswordAuthentication yes   #（可选）设置是否使用普通密码验证�
 # service sshd restart
 ```
 
-### 保持 SSH 在线
-
-- 服务端设置：
-
-编辑 `/etc/ssh/sshd_config`，调整 `ClientAlive` 的设置：
-
-```sh
-ClientAliveInterval 10 # 检测间隔
-ClientAliveCountMax 3 # 超时次数
-```
-
-`ClientAliveInterval` 默认是 `0`，即禁用检测。
-
-- 客户端设置：
-
-全局用户编辑 `/etc/ssh/ssh_config`；仅当前用户编辑 `~/.ssh/config`。
-
-```sh
-Host *
-ServerAliveInterval 10
-ServerAliveCountMax 3
-```
-
-或在连接的时候使用 `-o` 指定参数：
-
-```sh
-# ssh user@server -p 22 -o ServerAliveInterval=10 -o ServerAliveCountMax=3
-```
-
-客户端和服务端任一开启检测即可。
 
 ## SSH 密钥登录
 
@@ -433,7 +403,6 @@ root     syslogd     1017 7   udp4   *:514                 *:*
 
 ## 参考文献
 
-- [FreeBSD 入门笔记](https://lvv.me/posts/2021/04/19_freebsd_101/)，作者 lvv.me
 - [mosh FAQ](https://mosh.org/#faq)
 - [ssh && mosh](https://silbertmonaphia.github.io/ssh%E7%99%BB%E5%BD%95%E3%81%AE%E5%91%A8%E8%BE%BA-&&-Mosh.html)
 - [scp — OpenSSH secure file copy](https://man.openbsd.org/scp.1)


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

移除 FreeBSD SSH 配置指南中不必要的内容。

文档：
- 移除了解释如何配置 SSH keep-alive 的章节。
- 移除 FreeBSD 备注的外部参考链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unnecessary content from the FreeBSD SSH configuration guide.

Documentation:
- Remove the section explaining how to configure SSH keep-alive.
- Remove an external reference link for FreeBSD notes.

</details>