### PR TITLE
补遗

### DIFF
--- a/di-5-zhang-shu-ru-fa-ji-chang-yong-ruan-jian/di-5.1-jie-shu-ru-fa-yu-huan-jing-bian-liang.md
+++ b/di-5-zhang-shu-ru-fa-ji-chang-yong-ruan-jian/di-5.1-jie-shu-ru-fa-yu-huan-jing-bian-liang.md
@@ -78,10 +78,10 @@ LC_NUMERIC="C.UTF-8"
 LC_MONETARY="C.UTF-8"
 LC_MESSAGES=zh_CN.UTF-8
 LC_ALL=
-jk@freebsd:~ $ date
+$ date
 Fri Apr 21 21:14:43 UTC 2023
-jk@freebsd:~ $ export LC_TIME=zh_CN.UTF-8
-jk@freebsd:~ $ date
+$ export LC_TIME=zh_CN.UTF-8
+$ date
 2023年 4月21日 星期五 21时15分07秒 UTC
 ```
 
@@ -94,4 +94,4 @@ jk@freebsd:~ $ date
 
 >**注意**
 >
->维持 `date` 命令的英文输出对一些脚本有时很重要（这只是其中一种情况，还有其它特殊的需求等）。这样的情况亦存在于其它同样由 `LC_*` 变量控制的信息中。
+>维持 `date` 命令的英文输出对一些脚本有时很重要（这仅是其中一种情况，还有其它特殊的需求等）。这样的情况亦同样存在于其它由 `LC_*` 变量控制的信息中。


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

简化了一个代码示例，该示例演示了环境变量对 `date` 命令的影响，并删除了相关的注释。

文档：
- 从代码示例中的命令提示符中删除 user/host 前缀。
- 删除关于 `date` 命令在脚本中英文输出重要性的注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify a code example demonstrating environment variable effects on the `date` command and remove a related note.

Documentation:
- Remove user/host prefix from command prompts in a code example.
- Remove a note regarding the importance of English output for the `date` command in scripts.

</details>