### PR TITLE
五笔输入法

### DIFF
--- a/di-5-zhang-shu-ru-fa-ji-chang-yong-ruan-jian/di-5.4-jie-wu-bi-shu-ru-fa.md
+++ b/di-5-zhang-shu-ru-fa-ji-chang-yong-ruan-jian/di-5.4-jie-wu-bi-shu-ru-fa.md
@@ -49,24 +49,16 @@ schema_list:
 
 ## Fcitx 5
 
-首先安装并配置好 Fcitx 5。
 
 ### 安装 Fcitx 5 及 Rime 输入法
 
 ```sh
-# pkg install fcitx5 fcitx5-qt5 fcitx5-qt6 fcitx5-gtk2 fcitx5-gtk3 fcitx5-gtk4 fcitx5-configtool-qt5 fcitx5-configtool-qt6 zh-fcitx5-chinese-addons zh-rime-wubi
-```
-
-或者：
-
-```sh
-# cd /usr/ports/chinese/rime-wubi/
-# make install clean
+# pkg install fcitx5 fcitx5-qt5 fcitx5-qt6 fcitx5-gtk2 fcitx5-gtk3 fcitx5-gtk4 fcitx5-configtool-qt5 fcitx5-configtool-qt6 zh-fcitx5-chinese-addons 
 ```
 
 Fcitx 5 配置从略。
 
-### 下载配置所需文件
+### Fcitx 5 配置 98 五笔（可选）
 
 首先下载所需文件：<https://github.com/FreeBSD-Ask/98-input>。
 
@@ -85,6 +77,39 @@ Fcitx 5 配置从略。
 
 ```sh
 $ libime_tabledict 98wbx.txt 98wbx.main.dict
+```
+
+### Fcitx 5 配置 Rime（可选）
+
+
+首先安装并配置好 Fcitx 5。
+
+```sh
+# pkg ins zh-fcitx5-rime zh-rime-essay zh-rime-wubi 
+```
+
+或者：
+
+```sh
+# cd /usr/ports/chinese/rime-wubi/
+# cd /usr/ports/chinese/fcitx5-rime/ && make install clean
+# cd /usr/ports/chinese/rime-essay/ && make install clean
+```
+
+加入 Rime 的方法同上（Rime 输入法叫 `中州韵`），从略。
+
+修改 `/usr/local/share/rime-data/default.yaml`，如下：
+
+```
+# Rime default settings
+# encoding: utf-8
+
+config_version: '0.40'
+
+schema_list:
+  - schema: wubi86
+
+……其他省略……
 ```
 
 ## 配置文件目录


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 FreeBSD 上 Fcitx 5 输入法配置的文档，重点介绍五笔（98 版）和 Rime 输入法

文档：
- 修订了 Fcitx 5 和输入法的安装说明
- 更新了 98 五笔和 Rime 输入法的配置指南

杂项：
- 简化了软件包安装命令
- 重新组织了输入法设置的文档结构

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation for Fcitx 5 input method configuration on FreeBSD, focusing on Wubi (98 version) and Rime input methods

Documentation:
- Revised installation instructions for Fcitx 5 and input methods
- Updated configuration guidance for 98 Wubi and Rime input methods

Chores:
- Simplified package installation commands
- Reorganized documentation structure for input method setup

</details>