### PR TITLE
update to llvm20

### DIFF
--- a/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
+++ b/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
@@ -53,7 +53,7 @@ $ fetch -o ~/.vim/autoload/plug.vim https://raw.githubusercontent.com/junegunn/v
 
 ### coc.nvim 添加 clangd 补全
 
-Coc.nvim 是一个基于 NodeJS，适用于 Vim, Neovim 的 Vim 智能补全插件。拥有完整的 LSP (Language Server Protocol，简称 LSP。语言服务协议）支持。配置、使用方式及插件系统的整体风格类似 VSCode. clangd 用于支持 c/c++ 的 LSP。
+Coc.nvim 是一款基于 NodeJS，适用于 Vim, Neovim 的 Vim 智能补全插件。拥有完整的 LSP (Language Server Protocol，简称 LSP。语言服务协议）支持。配置、使用方式及插件系统的整体风格类似 VSCode. clangd 用于支持 c/c++ 的 LSP。
 
 安装 coc.nvim 依赖
 
@@ -136,23 +136,23 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 可自动生成 `compile_commands.json` 文件，有了这个文件再编辑源文件时就可以使用补全功能了。
 
-cmake 默认使用的是 系统自带的 clang (FreeBSD 13.1 自带 clang13），可以用
+cmake 默认使用的是系统自带的 clang，可以用
 
 ```sh
-$ export CC=clang15
-$ export CXX=clang++15
+$ export CC=clang20
+$ export CXX=clang++20
 ```
 
-再执行 cmake 以使用 clang15
+再执行 `cmake` 以使用 clang20。
 
-可以在 `.xprofile` 等文件中写入
+可以在 `.xprofile` 等文件中写入：
 
 ```sh
-export CC=clang15
-export CXX=clang++15
+export CC=clang20
+export CXX=clang++20
 ```
 
-以使得 clang15 clang++15 成为默认，但这应该根据项目要求进行。
+以使得 clang20、clang++20 成为默认，但这应该根据项目要求进行。
 
 ![](../.gitbook/assets/ccenv2.png)
 
@@ -164,7 +164,7 @@ export CXX=clang++15
 
 ### 代码美化
 
-vim-clang-format 四年未更新。故，对新的 clang-format 支持有问题（clang-format15 版本正常，clang-format17 和 clang-format19 不正常），所以推荐使用 vim-codefmt。
+vim-clang-format 多年未更新。因此对新的 clang-format 支持有问题（clang-format15 版本正常，clang-format17 和 clang-format19 不正常），故推荐使用 vim-codefmt。
 
 #### vim-codefmt 代码美化
 

--- a/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
+++ b/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
@@ -1,28 +1,33 @@
 # 第 22.4 节 C/C++ 环境的配置
 
-## 在 vim 下的配置
 
-### 配置 C/C++ 环境
+## 配置 C/C++ 环境
 
 下面的内容中需要使用到 llvm 的组件，其中：
 
-FreeBSD 自带 clang 编译器，但并不含 llvm 中其它组件如 clangd（语言服务器，用于代码补全，编译错误，定义跳转等），clang-format（用于格式化语言代码）。所以要安装 llvm，这里各版本的 llvm 都可用，不过至少不应比系统自带的 clang 版本低，在 FreeBSD 13.1 中 clang 版本为 13。下文使用 llvm15，安装后对应的 程序名为 clang15 clang++15 clangd15 clang-format15。而系统自带的 clang，程序名为 clang。如果使用不同版本请注意对照。
+FreeBSD 自带 Clang 编译器，但并不含 llvm 中其它组件，如 clangd（语言服务器，用于代码补全，编译错误，定义跳转等）、Clang-Tidy（代码风格诊断器）clang-format（用于格式化语言代码）。
+
+所以要安装 llvm，这里各版本的 llvm 都可用，不过至少不应比系统自带的 clang 版本低，在 FreeBSD 14.2 中 clang 版本为 18。
+
+下文使用 llvm20，安装后对应的程序名为 clang20、clang++20、clangd20、clang-format20。而系统自带的 clang，程序名为 `clang`。若使用不同版本请注意对照。
 
 ---
 
 - 使用 pkg 安装：
 
 ```sh
-# pkg install llvm15 cmake git
+# pkg install llvm20 cmake git
 ```
 
 - 或者使用 Ports 安装：
 
 ```
-# cd /usr/ports/devel/llvm15/ && make install clean
+# cd /usr/ports/devel/llvm20/ && make install clean
 # cd /usr/ports/devel/cmake/ && make install clean
 # cd /usr/ports/devel/git/ && make install clean
 ```
+
+## 配置 vim
 
 ### 安装 vim 及插件管理器
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 C/C++ 开发环境配置文档，以便在 FreeBSD 上使用 LLVM 20

文档：
- 将 LLVM 版本引用从 15 更新为 20
- 更新 Clang 版本引用以匹配 FreeBSD 14.2
- 增加了对 Clang-Tidy 作为附加 LLVM 工具的提及
- 重新组织了文档章节

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation for C/C++ development environment configuration to use LLVM 20 on FreeBSD

Documentation:
- Updated LLVM version references from version 15 to version 20
- Updated Clang version reference to match FreeBSD 14.2
- Added mention of Clang-Tidy as an additional LLVM tool
- Restructured documentation sections

</details>