### PR TITLE
补遗

### DIFF
--- a/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
+++ b/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
@@ -3,15 +3,13 @@
 
 ## 配置 C/C++ 环境
 
-下面的内容中需要使用到 llvm 的组件，其中：
-
 FreeBSD 自带 Clang 编译器，但并不含 llvm 中其它组件，如 clangd（语言服务器，用于代码补全，编译错误，定义跳转等）、Clang-Tidy（代码风格诊断器）clang-format（用于格式化语言代码）。
 
 所以要安装 llvm，这里各版本的 llvm 都可用，不过至少不应比系统自带的 clang 版本低，在 FreeBSD 14.2 中 clang 版本为 18。
 
 下文使用 llvm20，安装后对应的程序名为 clang20、clang++20、clangd20、clang-format20。而系统自带的 clang，程序名为 `clang`。若使用不同版本请注意对照。
 
----
+### 安装 Clang 环境包
 
 - 使用 pkg 安装：
 
@@ -84,29 +82,29 @@ call plug#end()
 :PlugInstall
 ```
 
-插件安装完成，仍在 vim 中，安装 json clangd cmake 补全插件
+插件安装完成，仍继续在 vim 中，安装 json clangd cmake 补全插件：
 
 ```sh
 :CocInstall coc-json coc-clangd coc-cmake
 ```
 
-配置 clangd 补全，在 vim 中
+配置 clangd 补全，在 vim 中：
 
 ```sh
 :CocConfig
 ```
 
-打开配置文件后，输入并保存
+打开配置文件后，输入并保存：
 
 ```sh
 {
-	"clangd.path":"clangd15"
+	"clangd.path":"clangd20"
 }
 ```
 
-此时已经可以使用 coc 进来补全了
+此时已经可以使用 coc 进来补全了。
 
-对简单的小程序，在源文件目录下新建 `compile_flags.txt` 文件，输入
+对简单的小程序，在源文件目录下新建 `compile_flags.txt` 文件，输入：
 
 ```sh
 -I/usr/local/include
@@ -114,7 +112,7 @@ call plug#end()
 
 如此可在 coc 可以用 `/usr/local/include` 下的头文件可以补全。
 
-对于复杂的项目，使用 `compile_commands.json` 文件设置补全。clangd 会在你文件的父目录中查找，也会在名为 build/ 的子目录中查找。例如，正在编辑 `$SRC/gui/window.cpp`, 会查找 `$SRC/gui/`, `$SRC/gui/build/`, `$SRC/`, `$SRC/build/` 等
+对于复杂的项目，使用 `compile_commands.json` 文件设置补全。clangd 会在你文件的父目录中查找，也会在名为 build/ 的子目录中查找。例如，正在编辑 `$SRC/gui/window.cpp`, 会查找 `$SRC/gui/`、`$SRC/gui/build/`、`$SRC/`、`$SRC/build/` 等
 
 以基于 CMake 的项目为例，在项目文件夹下
 
@@ -128,7 +126,7 @@ $ cd build
 $ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
 ```
 
-或者在 CMakeLists.txt 中
+或者在 `CMakeLists.txt` 中
 
 ```sh
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -156,11 +154,13 @@ export CXX=clang++20
 
 ![](../.gitbook/assets/ccenv2.png)
 
-此时已生成 compile_commands.json 文件，可以在 vim 中进行补全
+此时已生成 `compile_commands.json` 文件，可以在 vim 中进行补全
 
 ![](../.gitbook/assets/ccenv3.png)
 
-注意，以下操作在 sh/bash/zsh 中使用，csh/tcsh 请作相应改动
+>**注意**
+>
+>以下操作在 sh/bash/zsh 中使用，csh/tcsh 请作相应改动
 
 ### 代码美化
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新了 FreeBSD 中配置 C/C++ 开发环境的文档，重点介绍了 Clang 和 LLVM 工具链的设置。

增强功能：
- 更新了 clangd 的配置路径，从版本 15 更新到版本 20
- 改进了代码块和指令的格式

文档：
- 更新了 Clang 和 LLVM 环境配置的文档
- 阐明了 Clang 20 的安装和配置步骤
- 添加了格式并提高了文档的可读性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation for configuring C/C++ development environment in FreeBSD, focusing on Clang and LLVM toolchain setup

Enhancements:
- Updated clangd configuration path from version 15 to version 20
- Improved formatting of code blocks and instructions

Documentation:
- Updated documentation for Clang and LLVM environment configuration
- Clarified installation and configuration steps for Clang 20
- Added formatting and improved readability of documentation

</details>