### PR TITLE
删除冗余精简历史

### DIFF
--- a/di-1-zhang-zou-jin-freebsd/1.2-bsd-history.md
+++ b/di-1-zhang-zou-jin-freebsd/1.2-bsd-history.md
@@ -56,7 +56,7 @@ Keith Bostic 发起了一个项目，旨在在不使用 AT&T 的代码的前提�
 
 - 1992 年 USL 诉讼案
 
-BSDi 很快就陷入了与 AT&T 的 Unix System Laboratories（USL，Unix 系统实验室）子公司的法律纠纷中，当时 USL 是 System V 版权和 Unix 商标的所有者。USL 对 BSDi 的诉讼于 1992 年提起，并导致对 Net/2 的分发禁令。该诉讼于 1994 年 1 月达成和解。在 BSD 的 18,000 个文件中，仅须删除三个文件；并对 70 个文件进行修改，来展示 USL 版权声明。本次和解为首个 FreeBSD RELEASE 的发布铺平了道路。
+BSDi 很快就陷入了与 AT&T 的 Unix System Laboratories（USL，Unix 系统实验室）子公司的法律纠纷中，当时 USL 是 System V 版权和 Unix 商标的所有者。USL 对 BSDi 的诉讼于 1992 年提起，并导致对 Net/2 的分发禁令。该诉讼于 1994 年 1 月达成和解。在 BSD 的 18,000 个文件中，仅须删除三个文件；并对 70 个文件进行修改，用以展示 USL 版权声明。本次和解为首款 FreeBSD RELEASE 的发布铺平了道路。
 
 - 1993 年 6 月 FreeBSD 的创建
 
@@ -70,29 +70,13 @@ FreeBSD 的 Ports 和软件包为用户和管理员提供了一种简单的安�
 
 ipfirewall 是在 FreeBSD 2.0-RELEASE 中被引入的，这种“先入为主（First Match）”防火墙自此成为操作系统的重要组成部分。ipfw 曾作为 Mac OS X 的内置防火墙而广泛使用。
 
-- 1996 年 8 月 FreeBSD 2.1.5
-
-FreeBSD 2.1.5 发布于 1996 年 8 月，迅速在互联网服务提供商（ISP）和商业社区中广受到欢迎。该版本对于 FreeBSD 来说是个巨大的成功。
-
 - 1998 年 5 月 软更新（Soft Updates）
 
 1998 年 5 月，FreeBSD 采用了软更新依赖跟踪系统。软更新旨在通过跟踪和执行更新之间的依赖关系，保持文件系统元数据的完整性，以防发生崩溃和停电。
 
-- 1998 年 10 月 16 日 FreeBSD 3.0-RELEASE
-
-FreeBSD 3.0-RELEASE 于 1998 年 10 月 16 日宣布发布，为 i386 带来了最原始的对称多处理（SMP）支持。3.0-RELEASE 还默认使用了 SCSI 通用访问方法（CAM）。
-
-- 1998 年 11 月 29 日 FreeBSD 2.2.8-RELEASE
-
-FreeBSD 2.2.8-RELEASE 于 1998 年 11 月 29 日发布（在 FreeBSD 3 发布后一个月）。FreeBSD 2 的最终分支涉及 sendfile 和 dummynet 两个关键特性，这些特性在后续的 FreeBSD 版本中得到了进一步的发展。
-
 - 1999 年 10 月 17 日 首届 BSD 大会
 
 首届 FreeBSD 大会（FreeBSDCon'99）在加利福尼亚州伯克利举行。来自世界各地的 300 多名开发者和用户参加了此次活动，标志着 FreeBSD 在受欢迎度和影响力上的一个重要里程碑。
-
-- 2000 年 3 月 14 日 FreeBSD 4.0-RELEASE
-
-于 2000 年 3 月 14 日宣布发布的 FreeBSD 4.0-RELEASE 带来了大量的新功能和工具。该版本包括原始的 IPv6 支持和 IPsec 支持，两者都依赖于 KAME 代码；还有 OpenSSH、过滤器 `accept()` 以及带有基本支持的 802.11b WiFi 的 wi(4)。
 
 - 2000 年 3 月 14 日 FreeBSD Jail
 
@@ -114,9 +98,6 @@ kqueue(2) 是取代 select/poll 的创新解决方案，于 2000 年 7 月 27 �
 
 EuroBSDCon 2001 于 2001 年末在英国布莱顿举行。随着全球社区的不断扩大，EuroBSDCon 的目标是聚集在 BSD 操作系统家族及相关项目上工作的用户和开发者。
 
-- 2003 年 1 月 19 日 FreeBSD 5.0-RELEASE
-
-FreeBSD 5.0-RELEASE 经历了近 3 年的开发，由于引入了先进的多线程内核，提供更好的 SMP 支持，因此备受期待。
 
 - 2004 年 1 月 9 日 AMD64 磁盘镜像
 
@@ -146,17 +127,11 @@ Deb Goodkin 于 2005 年加入基金会，成为首位执行董事。她之前�
 
 举行了一项 Logo 设计大赛，由 Anton K. Gural 设计的 Logo 获胜（当前仍在使用）。
 
-- 2005 年 11 月 4 日 FreeBSD 6.0-RELEASE
-
-FreeBSD 6.0-RELEASE 于 2005 年 11 月 4 日发布。FreeBSD 6.0 首次提交了支持 32 位 Arm 的 sys/arm/arm，丰富了 802.11 WiFi 支持，扩展了高级功能，并通过 libthr(3) 和进一步的内核修改增加了 1:1 用户级线程。
 
 - 2007 年 JEMALLOC
 
 Jason Evans 于 2005 年开发了 jemalloc，这是一款内存分配器。与此同时，FreeBSD 需要一款可扩展的多处理器内存分配器，因此 Evans 将 jemalloc 集成到了 FreeBSD 的 libc 中，这改进了其可扩展性和碎片化行为。
 
-- 2008 年 2 月 27 日 FreeBSD 7.0-RELEASE
-
-因为担心 ULE 调度器的就绪状态，在发布时，FreeBSD 7.0-RELEASE 将其作为内核可选参数搭载，它在下一个稳定版本中成为了默认的调度程序。FreeBSD 7.0 还添加了 SCTP 协议以及与网络、音频和多处理器性能相关的重大更新。
 
 - 2008 年 3 月 ZFS
 
@@ -165,10 +140,6 @@ Jason Evans 于 2005 年开发了 jemalloc，这是一款内存分配器。与�
 - 2009 年 1 月 6 日 DTrace
 
 Sun Microsystems 开发了 DTrace，DTrace 可用于实时调试生产系统中的内核和应用程序问题。尽管该程序最初是为 Solaris 开发的，但它成为 FreeBSD 的标准组成部分，并为 DTrace 提供了全面支持。
-
-- 2009 年 11 月 25 日 FreeBSD 8.0-RELEASE
-
-FreeBSD 8.0-RELEASE 于 2009 年 11 月 25 日宣布发布，其中包含了 XEN domU 支持、VNET、透明超级页、改进的 ZFS 支持以及新的 USB 堆栈，涉及 USB 3.0 支持。
 
 - 2010 年 8 月 Capsicum
 
@@ -182,10 +153,6 @@ Capsicum 是一款轻量级的操作系统能力和沙盒框架。它可以用�
 
 Poudriere 是一款通过 jail 测试 port，并继而构建 FreeBSD 镜像的工具，它被添加到了 Ports 中。
 
-- 2012 年 1 月 12 日 FreeBSD 9.0-RELEASE
-
-FreeBSD 9.0-RELEASE 发布于 2012 年 1 月 12 日，其中包括了全新的安装程序——`bsdinstall`。其他主要特性包括软更新日志（SUJ）、NFS 版本 4 和模块化拥塞控制。FreeBSD 9 是索尼用于开发 PlayStation 4 操作系统（Obris OS）所使用的版本。
-
 - 2012 年 4 月 12 日 CLANG/LLVM
 
 LLVM 项目是一组模块化和可重用的编译器和工具链技术。Clang 项目为 LLVM 项目提供了 C 语言前端和工具基础设施。这些程序目前是 FreeBSD 的编译基础设施。
@@ -198,37 +165,19 @@ LLVM 项目是一组模块化和可重用的编译器和工具链技术。Clang 
 
 ZFS 开源项目衍生于 OpenSolaris 项目。在 2013 年 9 月 17 日，ZFS 开源项目宣布 OpenZFS 成为 ZFS 的继任者，并创建了一家正式的社区来维持开发和支持。
 
-- 2014 年 1 月 20 日 FreeBSD 10.0-RELEASE
 
-于 2014 年 1 月 20 日宣布发布 FreeBSD 10.0-RELEASE，带来了大量的新功能和工具。10.0 版本搭载了 pkg(7)（并切换到 pkgng），这个新的软件包管理工具能让用户不再需要手动编译 Port。该发布还包括 FUSE 实现、高级 iSCSI 支持（包括目标（服务器）和发起者（客户端））、VirtIO 驱动程序、bhyve 虚拟化技术和 amd64 架构上的 UEFI 支持。
+- 2014 年 1-2 月 FreeBSD 期刊创刊号
 
-- 2014 年 1-2 月 FreeBSD Journal FreeBSD 期刊创刊号
+作为 FreeBSD 社区的声音，并是跟进 FreeBSD 最新发布版本和新进展的最佳途径，FreeBSD 期刊的创刊号是 2014 年 1/2 月刊，重点关注 FreeBSD 10。
 
-作为 FreeBSD 社区的声音，并是跟进 FreeBSD 最新发布版本和新进展的最佳途径，FreeBSD Journal 的创刊号是 2014 年 1/2 月刊，重点关注 FreeBSD 10。
-
-- 2016 年 10 月 10 日 FreeBSD 11.0-RELEASE
-
-在 2016 年 10 月 10 日宣布发布 FreeBSD 11.0-RELEASE。该版本包含了对无线网络的多项改进以及集成 UDP-lite。最重要的是，FreeBSD 11 还涉及对 aarch64（arm64）的支持，aarch64 最初被分类为二级架构。
-
-- 2017 年 6 月 19 日 首个“FreeBSD Day”
+- 2017 年 6 月 19 日 首个“FreeBSD 日”
 
 国际 FreeBSD 日是每年一度的庆祝活动，旨在赞扬 FreeBSD 对技术的开创性和持续影响，并纪念其传承的价值。
 
-- 2018 年 12 月 11 日 FreeBSD 12.0-RELEASE
-
-2018 年 12 月 11 日发布的 FreeBSD 12.0 版本增强了对 AMD CPU 的支持，并显著提升了对现代显卡的支持。此外，还新增了开放指令集架构（ISA）RISC-V 的支持。
 
 - 2021 年 4 月 6 日 Git 迁移完成
 
 于 2021 年 4 月 6 日 完成了从 Subversion 到 Git 的迁移。此过程始于 2019 年 5 月的 DevSummit，当时成立了一个 Git 工作小组。
-
-- 2021 年 4 月 13 日 FreeBSD 13.0-RELEASE
-
-FreeBSD 13.0-RELEASE 于 2021 年 4 月 13 日发布。尽管 aarch64 从 FreeBSD 11 开始就得到了支持，但它在 FreeBSD 13.0-RELEASE 中才被提升为一级平台，成为首个非 x86 架构的一级平台。13.0 还涉及内核 TLS 卸载、升级了 clang 和 LLVM，移除了弃用的库、工具。
-
-- 2023 年 11 月 20 日 FreeBSD 14.0-RELEASE
-
-FreeBSD 14.0-RELEASE 于 2023 年 11 月 20 日发布。`portsnap` 已被弃用。64 位可执行文件默认启用了地址空间布局随机化（ASLR）。
 
 
 ## 参考文献


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 简化了 FreeBSD 历史文档，移除了冗长的版本发布详情。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Simplified the FreeBSD history document by removing verbose version release details

</details>