### PR TITLE
修正格式

### DIFF
--- a/di-13-zhang-freebsd-te-se/di-13.3-jie-bsdinstall-yu-bsdconfig.md
+++ b/di-13-zhang-freebsd-te-se/di-13.3-jie-bsdinstall-yu-bsdconfig.md
@@ -793,9 +793,9 @@ FreeBSD 还支持多个“虚拟控制台”，你可以使用它们同时进行
 
 | 菜单 | 说明 |
 | --- | --- |
-| X Exit Return to previous menu | X 退出 返回上一级菜单 |
-| > Add New Add new directive | > 添加 新增指令 |
-| > Delete Delete directive(s) | > 删除 删除指令 |
+| `X Exit Return to previous menu` | 退出 返回上一级菜单 |
+| `> Add New Add new directive` |  添加 新增指令 |
+| `> Delete Delete directive(s)` |  删除 删除指令 |
 
 查看配置当前正在使用的的启动项。
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复中文 FreeBSD 安装指南中的表格格式，通过将菜单命令用代码标记包裹并清理翻译列。

文档：
- 为菜单表格中的英文菜单命令添加代码格式
- 从翻译列中删除多余的英文文本

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix table formatting in the Chinese FreeBSD installation guide by wrapping menu commands in code ticks and cleaning up the translation column.

Documentation:
- Wrap English menu commands in code formatting for the menu table
- Remove redundant English text from the translation column

</details>