### PR TITLE
使用 pkgbasify 脚本

### DIFF
--- a/di-3-zhang-bao-guan-li-qi/di-3.9-jie-shi-yong-pkgbase-geng-xin.md
+++ b/di-3-zhang-bao-guan-li-qi/di-3.9-jie-shi-yong-pkgbase-geng-xin.md
@@ -4,14 +4,17 @@
 
 **pkgbase 的设计初衷是为了让 stable、current 和 release（BETA、RC 等）都能使用一种二进制工具进行更新。当下，stable、current 只能通过完全编译源代码的方式来更新。**
 
-目前不清楚是否让系统组件成为可选的部分（比如 cron、ntp 等第三方软件），这样就可以在 `bsdinstall` 安装的时候选择系统组件了。
-
 >**警告**
 >
->**存在风险，可能会丢失所有数据！**
+>**存在风险，可能会丢失所有数据！建议在操作之前做好备份。**
 
-## 配置软件源
+## 下载 `pkgbasify` 脚本
 
+在 [Github 仓库](https://github.com/FreeBSDFoundation/pkgbasify)下载 `pkgbasify.lua` 脚本文件。
+
+## （可选）配置软件源
+
+FreeBSD 官方源的 pkgbase 信息如下：
 
 | **分支** | **更新频率** | **URL 地址** |
 | :---: | :---: | :--- |
@@ -25,15 +28,27 @@
 
 **以上表格的时间已转换为北京时间，即东八区时间。为 FreeBSD 官方镜像站时间。**
 
-以 FreeBSD 15.0-CURRENT 为例（当下仅支持 14 和 15）
+若官方源下载速度慢，可以考虑换成国内镜像。
 
-创建文件夹：
+修改 Lua 脚本中的 `create_base_repo_conf` 函数：
 
-```sh
-# mkdir -p /usr/local/etc/pkg/repos/
+```lua
+function create_base_repo_conf(path)
+	assert(os.execute("mkdir -p " .. path:match(".*/")))
+	local f <close> = assert(io.open(path, "w"))
+	assert(f:write(string.format([[
+FreeBSD-base: {
+  url: "%s",
+  mirror_type: "srv",
+  signature_type: "fingerprints",
+  fingerprints: "/usr/share/keys/pkg",
+  enabled: yes
+}
+]], base_repo_url())))
+end
 ```
 
-编辑配置文件 `/usr/local/etc/pkg/repos/FreeBSD-base.conf`，写入以下内容，保存退出：
+将软件源信息替换为下列镜像站中的任何一个：
 
 
 ### 南京大学开源镜像站 NJU
@@ -63,92 +78,21 @@ FreeBSD-base: {
 }
 ```
 
-### FreeBSD 官方镜像站
+## 运行 `pkgbasify.lua`
 
 ```sh
-FreeBSD-base: {
-  url: "pkg+https://pkg.FreeBSD.org/${ABI}/base_latest",
-  mirror_type: "srv",
-  signature_type: "fingerprints",
-  fingerprints: "/usr/share/keys/pkg",
-  enabled: yes
-}
+chmod +x pkgbasify.lua
+./pkgbasify.lua
 ```
-
-## 第一次安装更新
-
-- 刷新软件源：
-
-```sh
-root@ykla:~ #  pkg update 
-Updating FreeBSD repository catalogue...
-Fetching meta.conf:   0%
-FreeBSD repository is up to date.
-Updating FreeBSD-base repository catalogue...
-Fetching meta.conf: 100%    178 B   0.2kB/s    00:01    
-Fetching data.pkg: 100%   40 KiB  40.6kB/s    00:01    
-Processing entries: 100%
-FreeBSD-base repository update completed. 527 packages processed.
-All repositories are up to date.
-```
-
-- 安装 pkgbase：
-  
-```sh
-root@ykla:~ # pkg install -r FreeBSD-base -g 'FreeBSD-*' 
-Updating FreeBSD-base repository catalogue...
-FreeBSD-base repository is up to date.
-All repositories are up to date.
-Updating database digests format: 100%
-The following 527 package(s) will be affected (of 0 checked):
-
-New packages to be INSTALLED:
-	FreeBSD-acct: 15.snap20240806043323 [FreeBSD-base]
-
-            ……省略一部分……
-	FreeBSD-zoneinfo: 15.snap20240806043323 [FreeBSD-base]
-
-Number of packages to be installed: 527
-
-The process will require 5 GiB more space.
-1 GiB to be downloaded.
-
-Proceed with this action? [y/N]:
-```
-
-
-## 第一次安装 pkgbase 后的准备工作（仅需这一次，以后可能不再需要）
-
-还原配置文件（**如果不做这一步，你的密码都会被清零**）：
-
-```sh
-# cp /etc/ssh/sshd_config.pkgsave /etc/ssh/sshd_config
-# cp /etc/master.passwd.pkgsave /etc/master.passwd
-# cp /etc/group.pkgsave /etc/group
-# pwd_mkdb -p /etc/master.passwd
-# service sshd restart
-# cp /etc/sysctl.conf.pkgsave /etc/sysctl.conf
-```
-
-按照 WIKI，直接删掉旧系统的文件就行：
 
 >**注意**
 >
 >我测试的是纯净系统，没有任何多余配置及第三方程序（除了 pkg），仅开了 SSH 服务。
 
-```sh
-# find / -name \*.pkgsave -delete
-# rm /boot/kernel/linker.hints
-```
-
 
 >**警告**
 >
 >**存在风险，可能会丢失所有数据！**
-
->**技巧**
->
->**经测试，以后更新直接 `pkg upgrade` 即可，不再需要此节内容**
 
 ## 参考文献
 

--- a/di-3-zhang-bao-guan-li-qi/di-3.9-jie-shi-yong-pkgbase-geng-xin.md
+++ b/di-3-zhang-bao-guan-li-qi/di-3.9-jie-shi-yong-pkgbase-geng-xin.md
@@ -48,7 +48,20 @@ FreeBSD-base: {
 end
 ```
 
-将软件源信息替换为下列镜像站中的任何一个：
+将软件源信息替换为下列镜像站中的任何一个，例如：
+
+```lua
+function create_base_repo_conf(path)
+	assert(os.execute("mkdir -p " .. path:match(".*/")))
+	local f <close> = assert(io.open(path, "w"))
+	assert(f:write([[
+FreeBSD-base: {
+  url: "https://mirrors.ustc.edu.cn/freebsd-pkg/${ABI}/base_latest",
+  enabled: yes
+}
+]]))
+end
+```
 
 
 ### 南京大学开源镜像站 NJU


### PR DESCRIPTION
使用 pkgbasify 脚本来简化 pkgbase 初装。

#495

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

使用 `pkgbasify.lua` 脚本自动执行 pkgbase 的初始安装，并相应地简化文档。

**新特性：**

- 引入 `pkgbasify.lua` 脚本以自动化 pkgbase 设置。
- 提供一个示例 Lua 函数 (`create_base_repo_conf`)，以编程方式生成基本存储库配置。

**增强功能：**

- 在潜在数据丢失之前，向警告消息添加备份提醒。
- 包含从 GitHub 存储库下载 `pkgbasify` 并执行它的说明。
- 提供可选的官方和国内镜像配置详细信息，以加快下载速度。

**文档：**

- 从指南中删除过时的手动 pkgbase 安装和安装后配置步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate pkgbase initial installation using the pkgbasify.lua script and streamline documentation accordingly.

New Features:
- Introduce the pkgbasify.lua script for automating pkgbase setup.
- Provide a sample Lua function (create_base_repo_conf) to programmatically generate the base repository configuration.

Enhancements:
- Add backup reminder to warning message before potential data loss.
- Include instructions to download pkgbasify from the GitHub repository and execute it.
- Offer optional official and domestic mirror configuration details for faster downloads.

Documentation:
- Remove outdated manual pkgbase installation and post-install configuration steps from the guide.

</details>