### PR TITLE
补遗

### DIFF
--- a/di-15-zhang-freebsd-fang-huo-qiang/di-15.5-fail2ban.md
+++ b/di-15-zhang-freebsd-fang-huo-qiang/di-15.5-fail2ban.md
@@ -117,7 +117,7 @@ bsdftp.conf			mysqld-auth.conf		sogo-auth.conf
 courier-auth.conf		nginx-botsearch.conf		sshd.conf
 ```
 
-需要注意，以 `bsd-` 开头的文件（如 `bsd-sshd.conf`）是 FreeBSD Port 维护者打的补丁。但是疏于维护？应该直接使用 `sshd.conf`。已经报告 bug。[security/py-fail2ban: Is it possible to remove patch-config_filter.d_bsd-sshd.conf from py-fail2ban?](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285647)
+需要注意，以 `bsd-` 开头的文件（如 `bsd-sshd.conf`）是 FreeBSD Port 维护者打的补丁。但是疏于维护？并不能使用。应该直接使用 `sshd.conf`。已经报告 bug。[security/py-fail2ban: Is it possible to remove patch-config_filter.d_bsd-sshd.conf from py-fail2ban?](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285647)，对方拒绝接受这是 bug。
 
 - ② 查看 Fail2Ban 支持的防火墙：
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在 Fail2Ban FreeBSD 文档中明确指出，带有 `bsd-` 前缀的过滤器文件不可用，并说明 FreeBSD Port 维护人员拒绝将其视为 bug。

文档：
- 更新关于带有 `bsd-` 前缀的配置文件的说明，声明它们不能使用，应该替换为标准的 `sshd.conf`。
- 提及相关的 bug 报告已被 FreeBSD Port 维护人员拒绝。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify in the Fail2Ban FreeBSD documentation that the `bsd-` prefixed filter files are unusable and note that the FreeBSD Port maintainers have refused to treat this as a bug.

Documentation:
- Update the note on `bsd-` prefixed config files to state they cannot be used and should be replaced with the standard `sshd.conf`
- Mention that the related bug report was rejected by the FreeBSD Port maintainers

</details>