### PR TITLE
up

### DIFF
--- a/di-16-zhang-fu-wu-qi/di-16.5-jie-wildfly.md
+++ b/di-16-zhang-fu-wu-qi/di-16.5-jie-wildfly.md
@@ -115,7 +115,3 @@ Added user 'test' with groups  to file '/usr/local/wildfly/domain/configuration/
 ## 故障排除与未竟事宜
 
 - 如果服务无法正常启动，可以通过 `/var/log/wildfly/error`、`/var/log/wildfly/log` 查看错误日志。
-
-- WildFly GUI 界面不知道怎么设置中文
-
-待解决


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

移除 WildFly 域配置文档中未解决的故障排除说明

文档：
- 移除关于在 WildFly GUI 中设置中文语言的说明
- 移除 '待解决' TODO 条目

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unresolved troubleshooting notes from WildFly domain configuration doc

Documentation:
- Remove note about setting Chinese language in WildFly GUI
- Remove '待解决' TODO entry

</details>