### PR TITLE
修订

### DIFF
--- a/di-15-zhang-freebsd-fang-huo-qiang/di-15.5-fail2ban.md
+++ b/di-15-zhang-freebsd-fang-huo-qiang/di-15.5-fail2ban.md
@@ -19,7 +19,7 @@
 
 - 配置服务：
 
-```
+```sh
 # service fail2ban enable
 ```
 
@@ -60,7 +60,7 @@ ports in the action so you shouldn't do it yourself.
 
 >**注意**
 >
->这个 `jail`，不是 BSD 里那个 jail（一种容器）。这个 jail 就是“封禁”这个字面意思。
+>这个 `jail`，不是 BSD 里那个 jail（一种容器）。这个 jail 就是“封禁”这个词的字面意思。
 
 配置实例在 `/usr/local/etc/fail2ban/jail.conf`（勿直接编辑，参见上文）。仅列出本文所需内容：
 
@@ -117,7 +117,7 @@ bsdftp.conf			mysqld-auth.conf		sogo-auth.conf
 courier-auth.conf		nginx-botsearch.conf		sshd.conf
 ```
 
-需要注意，以 `bsd-` 开头的文件（如 `bsd-sshd.conf`）是 FreeBSD Port 维护者打的补丁。但是疏于维护？并不能使用。应该直接使用 `sshd.conf`。已经报告 bug。[security/py-fail2ban: Is it possible to remove patch-config_filter.d_bsd-sshd.conf from py-fail2ban?](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285647)，对方拒绝接受这是 bug。
+需要注意，以 `bsd-` 开头的文件（如 `bsd-sshd.conf`）是 FreeBSD Port 维护者打的补丁。但是在本文中并不能使用。应该直接使用 `sshd.conf`。
 
 - ② 查看 Fail2Ban 支持的防火墙：
 
@@ -147,25 +147,24 @@ action=bsd-ipfw
 
 配置解释：
 
-- `192.168.0.0/24` 即 `192.168.0.0` 到 `192.168.0.254`
+- 白名单，不会被封禁的 IP 段。`192.168.0.0/24` 即 `192.168.0.0` 到 `192.168.0.254`
 - `bsd-ipfw` 是示例防火墙。你可自选。参见下文。
 
 >**警告**
 >
->若你使用 IPFW，则必须使用 `bsd-ipfw`。因为 `ipfw` 不会生效！
+>若你使用 IPFW，则必须使用 `bsd-ipfw` 而不是  `ipfw`。因为 `ipfw` 不会生效！
 
 ## 配置防火墙
 
 先启动 fail2ban：
 
-```
+```sh
 # service fail2ban start
 ```
 
-
 ### IPFW
 
-Fail2Ban 配置见上节。
+Fail2Ban 配置同上。
 
 #### 配置自启服务
 
@@ -177,7 +176,7 @@ Fail2Ban 配置见上节。
 >
 >**不要** 顺手 `start` 了。否则你将连不上 ssh 了。
 
-#### 默认允许通过
+#### 修改 IPFW 默认规则
 
 - IPFW 规则是“默认拒绝”，我们改成“默认允许”
 
@@ -194,7 +193,6 @@ Fail2Ban 配置见上节。
 65535 allow ip from any to any
 ```
 
-
 #### 参考文献
 
 - [man ipfw(8)](https://man.freebsd.org/cgi/man.cgi?ipfw(8))，man 页面
@@ -204,20 +202,17 @@ Fail2Ban 配置见上节。
 
 #### fail2ban 配置文件
 
-将上方配置文件 `/usr/local/etc/fail2ban/jail.d/sshd.conf` 中 `action=bsd-ipfw` 改为 `action = pf[port={22 23}, name=ssh]`，其他不需要改。
-
-#### 服务
-
-```sh
-# kldload pf # 加载内核模块，后边就不需要了
-# cp /usr/share/examples/pf/pf.conf /etc # 复制示例文件，否则 PF 无法启动。
-# service pf enable # 开机自启
-# service pf start # 启动 PF 防火墙！
-```
+将上方配置文件 `/usr/local/etc/fail2ban/jail.d/sshd.conf` 中 `action=bsd-ipfw` 改为 `action=pf[port={22 23}, name=ssh]`，其他不需要改。
 
 #### 修改 PF 配置文件
 
-编辑  `/etc/pf.conf`，写入：
+- 复制示例文件，否则 PF 无法启动。
+
+```sh
+# cp /usr/share/examples/pf/pf.conf /etc/ 
+```
+
+- 编辑  `/etc/pf.conf`，写入：
 
 ```ini
 table <f2b> persist
@@ -225,19 +220,21 @@ anchor "f2b/*"
 block drop in log quick on em0 from <f2b> to any
 ```
 
-- `em0`：上面的 `em0` 是我的网卡名，你要改成你自己的。
+- `em0`：上面的 `em0` 是我的网卡名，你要改成你自己的，可使用命令 `ifconfig` 查看。
+
+#### 服务
+
+```sh
+# kldload pf # 加载内核模块，后边就不需要了
+# service pf enable # 开机自启
+# service pf start # 启动 PF 防火墙！
+```
 
 ##### 参考文献
 
 - [fail2ban does not feed pf table](https://forums.freebsd.org/threads/fail2ban-does-not-feed-pf-table.67798/)
 - [Fail2ban on FreeBSD drops complete pf firewall rules](https://github.com/fail2ban/fail2ban/issues/1915)
 
-#### 测试 pf
-
-```sh
-root@ykla:/home/ykla # pfctl -a "f2b/sshd" -t f2b-sshd -Ts
-   192.168.179.1
-```
 
 ### IPFILTER (IPF)
 
@@ -313,6 +310,3 @@ Status for the jail: sshd
 ## 故障排除与未竟事宜
 
 - `fail2ban` 的日志在 `/var/log/fail2ban.log`
-
-
-


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修订 Fail2ban FreeBSD 指南，以提高可读性和格式，改进中文翻译，并简化 IPFW 和 PF 配置说明。

增强功能：
- 向代码围栏添加 shell 语言提示并标准化 markdown 格式
- 改进中文术语（例如“jail”）和防火墙警告，删除过时的错误引用
- 澄清 IPFW 白名单描述和 PF 设置步骤，包括 ifconfig 使用技巧
- 删除冗余的 PF 测试部分并简化配置说明

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revise the Fail2ban FreeBSD guide to improve readability and formatting, refine Chinese translations, and streamline IPFW and PF configuration instructions.

Enhancements:
- Add shell language hints to code fences and standardize markdown formatting
- Refine Chinese terminology (e.g. “jail”) and firewall warnings, removing an outdated bug-reference
- Clarify IPFW whitelist description and PF setup steps, including an ifconfig usage tip
- Remove redundant PF testing section and simplify configuration instructions

</details>