### PR TITLE
typo

### DIFF
--- a/qian-yan.md
+++ b/qian-yan.md
@@ -131,7 +131,7 @@ Windows 测试环境为 Windows 10、11，并尽量使用最新版本的 Windows
 | ![UNIX 网络编程 卷 2：进程间通信（第 2 版）](./.gitbook/assets/unix2.png) | 《UNIX 网络编程 卷 2：进程间通信（第 2 版）》 | W. Richard Stevens | 9787115367204 | 人民邮电出版社 | 深入了解各种进程间通信形式。**这书原作者没出第 3 版，不用再找了** |
 | ![深入理解 UNIX 系统内核](./.gitbook/assets/unixinternals.png) | 《深入理解 UNIX 系统内核》 | Uresh Vahalia | 9787111491453 | 机械工业出版社 | UNIX 内核基础 |
 | ![Unix 四分之一世纪](./.gitbook/assets/unix25.png) | 《Unix 四分之一世纪》|  Peter H. Salus | 9780201547771| Addison-Wesley Professional | 历史书，中译本在[此](https://freebsd.gitbook.io/unix-er-shi-wu-nian) |
-| ![Unix 痛恨者手册](./.gitbook/assets/unixno.png) | 《Unix 痛恨者手册》 | Simson Garfinkel、Daniel Weise、Steven Strassmann | 9781568842035 |  IDG Books Worldwide, Inc. |  历史书，中译本在[此](https://liuyandong.com/wp-content/uploads/2023/03/unix_haters_handbook.pdf) |
+| ![Unix 痛恨者手册](./.gitbook/assets/unixno.png) | 《Unix 痛恨者手册》 | Simson Garfinkel、Daniel Weise、Steven Strassmann | 9781568842035 |  IDG Books Worldwide, Inc. |  历史书，中译本在[此](https://book.bsdcn.org/unix-tong-hen-zhe-shou-ce) |
 
 ### 选读书目
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 更新指向中文版“Unix 痛恨者手册”的 URL，使用 BSDCN 托管的链接，而不是旧的 PDF 链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the URL pointing to the Chinese version of "Unix 痛恨者手册" to use the BSDCN-hosted link instead of the old PDF link

</details>