### PR TITLE
Windows 与 Unix 换行符/回车之差异

### DIFF
--- a/di-2-zhang-an-zhuang-freebsd/2.3-unix.md
+++ b/di-2-zhang-an-zhuang-freebsd/2.3-unix.md
@@ -91,3 +91,19 @@ abc	ABC
 
 - [调整区分大小写](https://learn.microsoft.com/zh-cn/windows/wsl/case-sensitivity)，Windows 文件系统支持使用属性标志按目录设置区分大小写
 
+## Windows 与 Unix 换行符/回车之差异
+
+回车（Carriage Return，CR）和“换行”（Line Feed，LF）是不同的概念，均产生于电传打字机（真 TTY）时代。
+
+- 回车 CR：将光标移动到当前行的开头部分；
+- 换行 LF：将光标竖直向下移动到下一行。
+
+可以看到在早期二者是独立的，否则 CRLF 会导致当前行“下沉”一行。
+
+Windows 操作系统默认的文本换行符为 CRLF（即 `\r\n`，0x0D 0x0A，`^M$`），而 Unix（早期 macOS 是 `\r`）默认使用 LF（即 `\n`，0x0A，`$`）。
+
+当然，现在这些符号都出现在每行文本的末尾处（即每行都存在）。
+
+二者是互不兼容的，如果你把 Windows 换行符的文件放到 Unix 下面，可能导致每行末尾多出一个 `^M` 字符，对于某些工具，会造成失败错误，对于 FreeBSD Port 相关文件来说，就是会把多行识别为一行。
+
+


### PR DESCRIPTION
好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

添加一个新的文档章节，详细介绍 CR 和 LF 的历史概念、Windows 与 Unix 中默认的行尾符，以及由此产生的跨平台兼容性问题

文档：
- 解释回车 (CR) 和换行 (LF) 从其 TTY 起源开始的不同作用
- 描述 Windows 默认的 CRLF (`\r\n`) 和 Unix 的 LF (`\n`) 行尾符，以及早期 macOS 使用 CR 的情况
- 警告将 CRLF 编码的文件移动到 Unix 时的不兼容性，例如多余的 `^M` 字符和 FreeBSD Port 失败

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new documentation section detailing the historical concepts of CR and LF, default line endings in Windows versus Unix, and the resulting cross-platform compatibility issues

Documentation:
- Explain the distinct roles of carriage return (CR) and line feed (LF) from their TTY origins
- Describe Windows’ default CRLF (`\r\n`) and Unix’s LF (`\n`) line endings and earlier macOS use of CR
- Warn about incompatibilities when moving CRLF-encoded files to Unix, such as stray `^M` characters and FreeBSD Port failures

</details>