### PR TITLE
Update 2.3-unix.md

### DIFF
--- a/di-2-zhang-an-zhuang-freebsd/2.3-unix.md
+++ b/di-2-zhang-an-zhuang-freebsd/2.3-unix.md
@@ -163,7 +163,7 @@ UTF-8
 
 有过 Windows 和 Unix 双系统安装经验的人会发现，Windows 和 Unix 的时间总是差 8 个小时。在现代计算机上（一般在主板上），都有一颗由纽扣电池供电的 RTC（Real-time clock，实时时钟芯片）芯片，用来维护系统断电后的计时。
 
-计算机操作系统在开机时会读取 RTC 的时间来设定系统的时间。localtime 即默认的本地时间，即直接读取 RTC 的结果（Windows 如此做）；UTC 则会把 RTC 的数据视为 UTC 时间（Unix 如此做）：于是你会发现双系统的时间倒流了 8 个小时。
+计算机操作系统在开机时会读取 RTC 的时间来设定系统的时间。localtime 即默认的本地时间，即直接读取 RTC 的结果（Windows 如此做）；UTC 则会把 RTC 的数据视为 UTC 时间（Unix 如此做）：于是你会发现双系统的时间倒流了 8 个小时。比如，如果 RTC 时间是“2025 年 6 月 6 日白天中午 12:00，那么 Windows 下，也是“2025 年 6 月 6 日白天中午 12:00”，但在 Unix 下，时间会变为“2025 年 6 月 6 日白天早上 4:00”.
 
 对于现代计算机网络来说，时间至关重要，我们可以做个小实验，把时间调慢 5 分钟，打开浏览器，你会发现绝大部分网站都打不开了（HTTPS）。
 
@@ -171,9 +171,9 @@ UTF-8
 
 中华民国二十八年（1939），民国政府将中国划分为五个时区，分为哈尔滨（`Asia/Harbin`）、上海（`Asia/Shanghai`）、重庆（`Asia/Chongqing`）、乌鲁木齐（`Asia/Urumqi`）和喀什（`Asia/Kashgar`）时间。
 
-我们知道，按照时区来说，重庆（`Asia/Chongqing`）是东七区。所以某些人说（Asia/Chongqing）等同于北京时间也是不对的。从地理上看，重庆与北京时间实际上相差了一个小时。
+我们知道，按照实际的地理时区来说，新疆是东六区（虽然全国统一使用北京时间）。从地理上看，新疆与北京时间实际上相差了二个小时。实际上，如果东八区八点太阳出来，那么新疆就是十点才出来。
 
-但在 2025b 中，`Asia/Harbin`、`Asia/Chongqing`、`Asia/Shanghai` 均等同于北京时间。`Asia/Urumqi` 和 `Asia/Kashgar` 则均为 `UTC+6` 东六区时间。
+在 2025b 中，`Asia/Harbin`、`Asia/Chongqing`、`Asia/Shanghai` 均等同于北京时间。`Asia/Urumqi` 和 `Asia/Kashgar` 则均为 `UTC+6` 东六区时间。
 
 在 FreeBSD 中，北京时间同样为 `Asia/Shanghai`（东八区）。有些所谓国产操作系统会无中生有一个 `Asia/beijing`，这不仅是不尊重规范的行为，并且会造成严重后果，如退回到 UTC 时间。
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强 Unix 时区部分，添加具体的 RTC 时间示例，并更正新疆的地理时区偏移量

文档：
- 添加一个说明性示例，展示 Windows 和 Unix 如何以不同的方式解释 RTC 时间
- 更正对新疆地理 UTC+6 偏移量的描述，以及其与北京时间相差两小时的描述

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the Unix time zone section with a concrete RTC time example and correct the geographical time zone offset for Xinjiang

Documentation:
- Add an illustrative example showing how Windows and Unix interpret RTC time differently
- Correct the description of Xinjiang’s geographical UTC+6 offset and its two-hour difference from Beijing time

</details>