### PR TITLE
将 RTC 时间视为地方时（兼容 Windows 时间，防止差 8 小时）

### DIFF
--- a/di-16-zhang-fu-wu-qi/di-16.4-jie-shi-jian-fu-wu.md
+++ b/di-16-zhang-fu-wu-qi/di-16.4-jie-shi-jian-fu-wu.md
@@ -38,6 +38,18 @@ CRON_TZ=CST-8
 0 8 * * * date >> ~/date.log
 ```
 
+- 将 RTC 时间视为地方时（兼容 Windows 时间，防止差 8 小时）
+
+```sh
+# touch /etc/wall_cmos_clock # 创建验证文件
+# reboot                     # 重启系统
+# sysctl machdep.wall_cmos_clock # 验证内核参数
+machdep.wall_cmos_clock: 1
+```
+
+### 参考文献
+
+- [adjkerntz ](https://man.freebsd.org/cgi/man.cgi?adjkerntz(8))
 
 ## 配置同步时间
 


### PR DESCRIPTION
好的，这是翻译成中文的pull request摘要：

## Sourcery 总结

将 RTC 时钟视为本地时间，以防止 8 小时的偏移，并提供验证步骤

文档：
- 添加说明，通过创建 /etc/wall_cmos_clock，重启并验证 machdep.wall_cmos_clock 内核参数，来配置系统将 RTC 时钟视为本地时间
- 包含对 adjkerntz(8) 手册页的引用，以获取更多信息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat the RTC clock as local time to prevent an 8-hour offset and provide verification steps

Documentation:
- Add instructions to configure the system to treat the RTC clock as local time by creating /etc/wall_cmos_clock, rebooting, and verifying the machdep.wall_cmos_clock kernel parameter
- Include a reference to the adjkerntz(8) man page for further information

</details>