### PR TITLE
补遗

### DIFF
--- a/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
@@ -166,7 +166,7 @@ FreeBSD 日为 6 月 19 日。FreeBSD 基金会和社区在这天庆祝 FreeBSD 
 
 ### UNIX 与忒修斯之船
 
-FreeBSD 是不是 UNIX？这个问题远没有想象中的那么简单、那么好回答。这其实是个复杂的涉及本体论的哲学问题（类似的问题如谷堆问题、秃头问题，感兴趣的读者可参见 SEP 条目“[Identity Over Time](https://plato.stanford.edu/entries/identity-time)”、“[Sorites Paradox](https://plato.stanford.edu/entries/sorites-paradox/)”）。
+FreeBSD 是不是 UNIX？这个问题远没有想象中的那么简单、那么好回答。它并非简单地能用法律上的商标归属或者代码上继承性进行分析的纯粹技术性难题。这其实牵涉到了一个深刻的本体论的哲学问题（类似的问题如谷堆问题、秃头问题，感兴趣的读者可参见 SEP 条目“[Identity Over Time](https://plato.stanford.edu/entries/identity-time)”、“[Sorites Paradox](https://plato.stanford.edu/entries/sorites-paradox/)”）。对这个问题回答如何，其实显露着读者的哲学观与科学技术观。
 
 >忒修斯和雅典青年安全返航所乘的是有三十支桨的大帆船，雅典人把这只船一直保存到德米特里·法勒琉斯的时代。他们一次又一次地拆掉了朽烂的旧船板，换上坚实的新船板。从此以后，这只船就成为哲学家们就事物的发展问题展开争论时经常援引的实例，一派认为它还是原来那只船，另一派争辩说它已不再是原来的船了。
 >

--- a/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
@@ -166,7 +166,11 @@ FreeBSD 日为 6 月 19 日。FreeBSD 基金会和社区在这天庆祝 FreeBSD 
 
 ### UNIX 与忒修斯之船
 
-FreeBSD 是不是 UNIX？这个问题远没有想象中的那么简单、那么好回答。它并非简单地能用法律上的商标归属或者代码上继承性进行分析的纯粹技术性难题。这其实牵涉到了一个深刻的本体论的哲学问题（类似的问题如谷堆问题、秃头问题，感兴趣的读者可参见 SEP 条目“[Identity Over Time](https://plato.stanford.edu/entries/identity-time)”、“[Sorites Paradox](https://plato.stanford.edu/entries/sorites-paradox/)”）。对这个问题回答如何，其实显露着读者的哲学观与科学技术观。
+FreeBSD 是不是 UNIX？
+
+这个问题远没有想象中的那么简单、那么明白。我看到不少讨论者，甚至是亲历当初那段岁月的人，亦难以回答或澄清。或者只是简单的说，BSD 并未进行过任何 UNIX 认证，没有持有法律上的商标就草草终结话题；更有甚者只是笼统地说 FreeBSD 是 UNIX 的延续者与正统继承者，仅是“有实无名”。还有人认为，BSD 之于 UNIX，正如 Linux 之于 UNIX。
+
+之所以有这些不同的回答，是因为这个问题不是能够简单地用法律上的商标归属或者代码上继承性进行分析的纯粹技术性难题。这其实牵涉到了一个深刻的本体论的哲学问题——我们究竟是不能两次踏进同一条河流，还是一次也不能踏进同一条河流？（类似的问题如谷堆问题、秃头问题，感兴趣的读者可参见 SEP 条目“[Identity Over Time](https://plato.stanford.edu/entries/identity-time)”、“[Sorites Paradox](https://plato.stanford.edu/entries/sorites-paradox/)”）。对这个问题回答如何，其实显露着读者的哲学观与科学技术观。
 
 >忒修斯和雅典青年安全返航所乘的是有三十支桨的大帆船，雅典人把这只船一直保存到德米特里·法勒琉斯的时代。他们一次又一次地拆掉了朽烂的旧船板，换上坚实的新船板。从此以后，这只船就成为哲学家们就事物的发展问题展开争论时经常援引的实例，一派认为它还是原来那只船，另一派争辩说它已不再是原来的船了。
 >


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在“UNIX 与忒修斯之船”一节中澄清，质疑 FreeBSD 是否为 Unix 涉及的不仅仅是技术或法律方面的考虑，而是将其定义为一个更深层次的本体论哲学问题，并指出回答揭示了一个人的哲学和科学技术视角。

文档：
- 扩展讨论，强调 Unix 身份问题超越了商标或代码沿袭，而取决于本体论哲学。
- 增加一个注释，说明如何回答这个问题反映了其潜在的哲学和技术观点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify in the “UNIX 与忒修斯之船” section that questioning whether FreeBSD is Unix involves more than technical or legal considerations, framing it as a deeper ontological philosophical issue and noting that responses reveal one’s philosophical and scientific-technical perspective.

Documentation:
- Expand the discussion to emphasize that the Unix identity question transcends trademark or code lineage and hinges on ontological philosophy.
- Add a note that how one answers this question reflects their underlying philosophical and technological views.

</details>