### PR TITLE
删除冗余

### DIFF
--- a/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
@@ -8,7 +8,10 @@
 
 ---
 
-查询美国专利商标局 UNIX 商标注册情况：
+查询美国专利商标局 UNIX 商标注册情况：![image](https://github.com/user-attachments/assets/487c397b-5eed-4de6-8d3c-a1c1dfb3d489)
+![image](https://github.com/user-attachments/assets/f463c9ef-7779-46d8-ac11-62d475dcb278)
+![image](https://github.com/user-attachments/assets/1227dbb1-ef23-40df-a125-b3e18d820f5a)
+
 
 ![法律上的商标](../.gitbook/assets/usshangbiao.png)
 
@@ -163,12 +166,6 @@ BSD 最初是由加州大学伯克利分校（University of California, Berkeley
 
 Free 则代表 Liberty 式自由和免费两种含义。
 
----
-
-FreeBSD 未进行过 UNIX 认证，从版权角度来看，FreeBSD 的确不是 UNIX。但从历史来看 FreeBSD 可以被视为 UNIX 的直系后裔。
-
-BSD 操作系统并非复制品，而是 AT&T 研究 UNIX（Research Unix）操作系统的开源衍生版本，也是现代 UNIX® System V 的祖先。在 4.4BSD 以前，BSD 全称为 BSD UNIX。
-
 FreeBSD 日为 6 月 19 日。FreeBSD 基金会和社区在这天庆祝 FreeBSD 的生日。——[Join us to celebrate FreeBSD Day!](https://freebsdfoundation.org/freebsd-day/)
 
 ### UNIX 之船：FreeBSD 是不是 UNIX？
@@ -183,6 +180,7 @@ FreeBSD 日为 6 月 19 日。FreeBSD 基金会和社区在这天庆祝 FreeBSD 
 >
 >- [古希腊] 普鲁塔克. 希腊罗马名人传[M]. 译者：黄宏煦 主编 / 陆永庭 / 吴彭鹏, 第1版. 商务印书馆, 1990-11. 第 23 页（23）。
 
+BSD 操作系统并非复制品，而是 AT&T 研究 UNIX（Research Unix）操作系统的开源衍生版本，也是现代 UNIX® System V 的祖先。在 4.4BSD 以前，BSD 全称为 BSD UNIX。
 
 最初，Unix 是 `AT&T` 开发的操作系统，可以获取源代码，但并非开源。在 20 世纪 70 年代末，伯克利大学的计算机系统研究小组（Computer Systems Research Group，CSRG）开始对 Unix 进行深入研究，并为其开发了大量用户空间的程序，形成了名为 BSD（Berkeley Software Distribution，伯克利软件套件）的新系统。随着时间推移，BSD 系统逐渐发展，加入了许多创新，比如实现了 TCP/IP 协议栈。尽管 Unix 内核经历了多个版本的演变，但到了 90 年代，Net/2 版本发布后，Unix 内核中的 AT&T 代码已经被完全替换，成为了一款没有专利代码的系统。BSD 系统逐渐演化成为 4.2BSD，BSD 4.4-lite……进而成为了 386BSD。
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在 UNIX 部分添加商标注册截图，移除关于 FreeBSD 认证和生日的多余历史记录，并将 BSD 起源描述重新定位以简化叙述。

增强功能：
- 插入三张显示 USPTO UNIX 商标注册状态的图片
- 移除关于 FreeBSD UNIX 认证和 FreeBSD Day 的多余段落
- 将 BSD 操作系统起源注释重新定位到更符合上下文的位置

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add trademark registration screenshots to the UNIX section, remove redundant historical notes on FreeBSD certification and birthday, and relocate the BSD origin description to streamline the narrative.

Enhancements:
- Insert three images showing the USPTO UNIX trademark registration status
- Remove redundant paragraphs about FreeBSD UNIX certification and FreeBSD Day
- Relocate the BSD operating system origin note to a more contextually appropriate location

</details>