### PR TITLE
重写 OpenBSD doas

### DIFF
--- a/di-26-zhang-openbsd/di-26.3-jie-pei-zhi.md
+++ b/di-26-zhang-openbsd/di-26.3-jie-pei-zhi.md
@@ -26,9 +26,20 @@
 
 ## 更新
 
-### 普通账号获取权限
+### doas
 
-以 root 账号登录系统，而后新建 `/etc/doas.conf` 文本，打开 `doas.conf`，添加一行 `permit persist :wheel`
+首先以 root 账号登录系统。执行命令：
+
+```sh
+# cp /etc/examples/doas.conf /etc/
+```
+
+由模板复制而来的 `/etc/doas.conf` 默认应包含 `permit keepenv :wheel` 这一行（要求用户属于 wheel 组才能实现 doas 命令，`keepenv` 即保留当前用户的环境变量）。
+
+如需 doas 免密码，应修改为 `permit nopass keepenv :wheel`。
+
+若想允许仅单个用户免密码使用 doas，可使用 `permit nopass keepenv 你的用户名 as root`，其中改成你的用户名即可。
+
 
 ### 更新与升级
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

修订 OpenBSD doas 文档，使用示例配置文件，并解释针对组范围和每个用户设置的 keepenv 和 nopass 选项

文档：
- 重写 doas 部分，指导复制 /etc/examples/doas.conf 而不是手动创建
- 增加对默认 permit keepenv :wheel 设置的解释，以及如何启用无密码 doas
- 包含为单个用户（作为 root 用户）授予 nopass doas 访问权限的指南

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revise the OpenBSD doas documentation to use the example configuration file and explain keepenv and nopass options for both group-wide and per-user setups

Documentation:
- Rewrite the doas section to instruct copying /etc/examples/doas.conf instead of manual creation
- Add explanation of the default permit keepenv :wheel setting and how to enable passwordless doas
- Include guidance for granting nopass doas access to a single user as root

</details>