### PR TITLE
OpenBSD 对 NVIDIA 显卡（n卡）的支持，大致停留在 2009 年左右的 GT200 系列，

### DIFF
--- a/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
+++ b/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
@@ -44,7 +44,7 @@ OpenBSD 软件包较少，过时的软件包都被移除了，新的来不及移
 
 >**注意**
 >
->OpenBSD 对 NVIDIA 显卡（N 卡）的支持，大致停留在 2009 年左右的 GT200 系列。
+>OpenBSD 对 NVIDIA 显卡（N 卡）的支持，大致停留在 2009 年左右的 GT200 系列。参见 [nv - NVIDIA video driver](https://man.openbsd.org/nv.4)。
 
 ### 文件系统
 

--- a/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
+++ b/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
@@ -44,7 +44,7 @@ OpenBSD 软件包较少，过时的软件包都被移除了，新的来不及移
 
 >**注意**
 >
->OpenBSD 对 NVIDIA 显卡（N 卡）的支持，大致停留在 2009 年左右的 GT200 系列。参见 [nv - NVIDIA video driver](https://man.openbsd.org/nv.4)。
+>OpenBSD 对 NVIDIA 显卡（N 卡）的支持，大致停留在 2009 年左右的 GT200 系列。参见 [nv - NVIDIA video driver](https://man.openbsd.org/nv.4)（具体硬件支持列表）。
 
 ### 文件系统
 

--- a/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
+++ b/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
@@ -42,6 +42,10 @@ OpenBSD 采用了 LLVM/Clang 项目来构建系统，默认 shell 为 ksh（Korn
 
 OpenBSD 软件包较少，过时的软件包都被移除了，新的来不及移植，举例来说你甚至找不到一个能用的登录管理器（gdm 除外）。
 
+>**注意**
+>
+>OpenBSD 对 NVIDIA 显卡（N 卡）的支持，大致停留在 2009 年左右的 GT200 系列。
+
 ### 文件系统
 
 OpenBSD 默认使用的文件系统 FFS 其实和 FreeBSD 的 UFS 是一回事，在挂载参数上都没有任何区别。


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

文档：
- 记录 OpenBSD 上 NVIDIA GPU 的支持大约在 2009 年代的 GT200 系列停止。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

文档：
- 记录 OpenBSD 上 NVIDIA GPU 的支持在 GT200 系列（大约 2009 年）左右停止，并提供指向 nv 驱动程序手册页面的链接

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document that NVIDIA GPU support on OpenBSD stops around the GT200 series (circa 2009) with link to nv driver man page

</details>

</details>