### PR TITLE
typo

### DIFF
--- a/di-4-zhang-zhuo-mian-an-zhuang/di-4.3-jie-an-zhuang-gnome.md
+++ b/di-4-zhang-zhuo-mian-an-zhuang/di-4.3-jie-an-zhuang-gnome.md
@@ -140,7 +140,7 @@ gnome 捆绑的输入法面板是 `ibus`。
 
 #### fcitx 5
 
-参见输入法相关章节。需要注意 ibus 是 gnome 的依赖，不能卸载。
+参见输入法相关章节。需要注意 IBus 是 gnome 的依赖，不能卸载。也就是说你可以不用 IBus，但是不能卸载。
 
 ![FreeBSD Gnome](../.gitbook/assets/gnome4-1.png)
 


### PR DESCRIPTION
## Sourcery 总结

文档：
- 将 IBus 正确地大写，并添加注释说明 GNOME 依赖于 IBus，因此无法卸载（尽管可以保持不使用状态）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Capitalize IBus correctly and add note that GNOME depends on IBus so it can’t be uninstalled (though it can remain unused).

</details>