### PR TITLE
补遗

### DIFF
--- a/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
@@ -117,12 +117,17 @@ Unix-like 即类 Unix，亦即一切符合 UNIX 标准的操作系统，基本�
 - 1983 年，RMS 发表[《GNU 宣言》](https://www.gnu.org/gnu/manifesto.html)，其中 GNU 即 GNU is Not Unix（GNU 不是 Unix）。GNU 是一款操作系统——旨在完全替代 Unix。
 - 1984 年，创建 [GNU 项目](https://www.gnu.org/)
 - 1985 年，RMS 创建自由软件基金会（Free Software Foundation，FSF）
+- 1989 年，FSF 发布 GPLv1 
+- 1991 年，FSF 发布 GPLv2
+- 2007 年，FSF 发布 GPLv3
 
 一开始他为 Unix 写了很多实用程序（用户空间），然而 GNU 的目标操作系统始终缺乏稳定的内核（即使到了 2025 年，[GNU Hurd](https://hurd.gnu.org/) 仍未完成）。Linux 内核的诞生为这一困境带来了突破。作为一款由 Linux 内核和 GNU 软件拼凑起来的操作系统，Linux 不断地的 GNU 化，成为了一款操作系统——这就是 GNU/Linux 其中 GNU 的来历，然而很多人无视这一事实，掩盖了 GNU 软件的贡献。
 
 Linux 内核由创始人 Linus Torvalds 一人裁决。所以显而易见的，Linux 的理念与自由软件运动的理念、乃至于同真正开源的理念（Linux 内核里存在大量非开源非自由的存在，参见 [Linux-libr](https://www.fsfla.org/ikiwiki/selibre/linux-libre/)）都存在明显的张力。并且 Linux 内核使用 GPLv2，而非 GNU 推荐的 GPLv3。
 
 我们将 Linux 之前这段时间称作“自由软件运动”（代表人物 RMS）。Linux 的流行促成了另一种理念的兴起，即“开源运动”——代表人物有 Eric S. Raymond，OSI（Open Source Initiative，开放源代码促进会）的创始人，《UNIX 编程艺术》、《大教堂与集市》的作者；Bruce Perens，Debian 项目前领导人——想想下面有关开源的定义为什么是自 [Debian 的开源定义 DFSG](https://www.debian.org/social_contract#guidelines) 衍生而来？
+
+自由软件运动并未停止，但人们对开源的误解却越来越重。
 
 ### 自由软件运动与开源运动之间的张力
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

补充 Unix 历史章节，加入 FSF GPL 发布日期，并强调在对开源存在误解的情况下，自由软件运动仍在继续。

文档：
- 在时间线中添加 FSF GPL 发布年份（GPLv1 于 1989 年，GPLv2 于 1991 年，GPLv3 于 2007 年）
- 注意到尽管对开源的误解日益加深，自由软件运动仍然存在

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Supplement the Unix history section with FSF GPL release dates and emphasize the ongoing free software movement amid misconceptions about open source.

Documentation:
- Add FSF GPL release years (GPLv1 in 1989, GPLv2 in 1991, and GPLv3 in 2007) to the timeline
- Note that the free software movement persists despite growing misunderstandings of open source

</details>