### PR TITLE
补遗

### DIFF
--- a/di-2-zhang-an-zhuang-freebsd/di-2.6-jie-an-zhuang-freebsd-ji-yu-virtual-box.md
+++ b/di-2-zhang-an-zhuang-freebsd/di-2.6-jie-an-zhuang-freebsd-ji-yu-virtual-box.md
@@ -157,11 +157,11 @@ You may ignore the yellow alert that encourages use of VMSVGA.
 
 xorg 可以自动识别驱动，**不需要** 手动配置 `/usr/local/etc/X11/xorg.conf`（经过测试手动配置反而更卡，点一下要用 5 秒钟……）。
 
-- 启动服务：
+- 服务自启动：
 
 ```sh
-# sysrc vboxguest_enable="YES"
-# sysrc vboxservice_enable="YES"
+# service vboxguest enable
+# service vboxservice enable
 ```
 
 - 启动服务，调整权限（以普通用户 ykla 为例）：
@@ -169,7 +169,7 @@ xorg 可以自动识别驱动，**不需要** 手动配置 `/usr/local/etc/X11/x
 ```sh
 # service vboxguest restart # 可能会提示找不到模块，但是不影响使用
 # service vboxservice restart
-# pw groupmod wheel -m ykla # 管理员权限
+# pw groupmod wheel -m ykla # 将笔者的普通用户 ykla 加入 wheel 组以获得权限，你需要改成你自己的普通用户
 ```
 
 ## 故障排除与未竟事宜
@@ -178,7 +178,7 @@ xorg 可以自动识别驱动，**不需要** 手动配置 `/usr/local/etc/X11/x
 
 编辑 `/etc/sysctl.conf`，添加
 
-```sh
+```ini
 hw.efi.poweroff=0
 ```
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

改进 FreeBSD VirtualBox 安装指南中的服务启动说明和文档格式

增强功能：
- 将 `sysrc` 命令替换为 `service enable` 命令，用于 `vboxguest` 和 `vboxservice`
- 澄清 `pw groupmod` 注释，指示将示例用户名替换为用户自己的用户名
- 将代码块语言从 `sh` 更改为 `ini`，用于 `sysctl.conf` 代码段
- 将“启动服务”部分标题重命名为“服务自启动”，以保持一致性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine service startup instructions and documentation formatting in the FreeBSD VirtualBox installation guide

Enhancements:
- Replace sysrc commands with service enable commands for vboxguest and vboxservice
- Clarify pw groupmod comment to instruct replacing the example username with the user’s own
- Change code block language from sh to ini for the sysctl.conf snippet
- Rename the “启动服务” section heading to “服务自启动” for consistency

</details>