### PR TITLE
add 最低硬件要求

### DIFF
--- a/di-2-zhang-an-zhuang-freebsd/2.1-install-pre.md
+++ b/di-2-zhang-an-zhuang-freebsd/2.1-install-pre.md
@@ -1,5 +1,16 @@
 # 第 2.1 节 安装前准备
 
+## 最低硬件要求
+
+针对 AMD64 架构，14.2-RELEASE 在物理机上测得：
+
+- 硬盘：
+  - 仅基本系统（安装后）：550MB
+  - KDE 桌面（pkg 安装后）：15G
+- 内存：
+  - UEFI 下，最小内存为 128N
+  - BIOS 下，最小内存为 64M
+
 ## FreeBSD 版本介绍
 
 已知 FreeBSD 有如下版本（或阶段）：alpha、rc、beta、release、current、stable。


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在安装准备工作中新增“最低硬件要求”章节，明确 AMD64 架构的最低磁盘空间和内存要求。

文档：
- 在 FreeBSD安装前准备 下新增最低硬件要求章节。
- 明确基本系统 (550MB) 和 KDE 桌面 (15GB) 的磁盘空间要求。
- 明确 UEFI (128MB) 和 BIOS (64MB) 下的最低内存要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new “最低硬件要求” section to the installation prerequisites that specifies minimum disk space and memory requirements for the AMD64 architecture.

Documentation:
- Introduce a minimum hardware requirements section under FreeBSD安装前准备.
- Specify disk space requirements for a basic system (550MB) and KDE desktop (15GB).
- Specify minimum memory requirements under UEFI (128MB) and BIOS (64MB).

</details>