### PR TITLE
操作系统的历程：UNIX、BSD、Linux 与 FreeBSD 的起源

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,7 +12,7 @@
 
 ## 第 1 章 FreeBSD 初见
 
-* [第 1.1 节 操作系统的历程：从 UNIX、Linux 到 FreeBSD](di-1-zhang-zou-jin-freebsd/di-1.1-unix.md)
+* [第 1.1 节 操作系统的历程：UNIX、BSD、Linux 与 FreeBSD 的起源](di-1-zhang-zou-jin-freebsd/di-1.1-unix.md)
 * [第 1.2 节 关于 FreeBSD 项目](di-1-zhang-zou-jin-freebsd/1.2-about-bsd.md)
 * [第 1.3 节 谁在使用 FreeBSD？](di-1-zhang-zou-jin-freebsd/di-1.3-who-using-bsd.md)
 * [第 1.4 节 为什么要使用 FreeBSD？](di-1-zhang-zou-jin-freebsd/di-1.4-jie-wei-shi-mo-yao-shi-yong-freebsd.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,7 +12,7 @@
 
 ## 第 1 章 FreeBSD 初见
 
-* [第 1.1 节 操作系统的历程：UNIX、Unix-like、Linux & FreeBSD](di-1-zhang-zou-jin-freebsd/di-1.1-unix.md)
+* [第 1.1 节 操作系统的历程：从 UNIX、Linux 到 FreeBSD](di-1-zhang-zou-jin-freebsd/di-1.1-unix.md)
 * [第 1.2 节 关于 FreeBSD 项目](di-1-zhang-zou-jin-freebsd/1.2-about-bsd.md)
 * [第 1.3 节 谁在使用 FreeBSD？](di-1-zhang-zou-jin-freebsd/di-1.3-who-using-bsd.md)
 * [第 1.4 节 为什么要使用 FreeBSD？](di-1-zhang-zou-jin-freebsd/di-1.4-jie-wei-shi-mo-yao-shi-yong-freebsd.md)

--- a/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
@@ -1,4 +1,4 @@
-# 第 1.1 节 操作系统的历程：从 UNIX、Linux 到 FreeBSD
+# 第 1.1 节 操作系统的历程：UNIX、BSD、Linux 与 FreeBSD 的起源
 
 ## 什么是 UNIX？
 

--- a/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
@@ -1,4 +1,4 @@
-# 第 1.1 节 操作系统的历程：UNIX、Unix-like、Linux & FreeBSD
+# 第 1.1 节 操作系统的历程：从 UNIX、Linux 到 FreeBSD
 
 ## 什么是 UNIX？
 

--- a/mu-lu.md
+++ b/mu-lu.md
@@ -1,4 +1,4 @@
-# Table of contents
+# 目录
 
 * [FreeBSD 从入门到追忆（第三版：草稿）](README.md)
 * [编辑日志](CHANGELOG.md)

--- a/mu-lu.md
+++ b/mu-lu.md
@@ -1,4 +1,4 @@
-# 目录
+# Table of contents
 
 * [FreeBSD 从入门到追忆（第三版：草稿）](README.md)
 * [编辑日志](CHANGELOG.md)
@@ -12,7 +12,7 @@
 
 ## 第 1 章 FreeBSD 初见
 
-* [第 1.1 节 操作系统的历程：从 UNIX、Linux 到 FreeBSD](di-1-zhang-zou-jin-freebsd/di-1.1-unix.md)
+* [第 1.1 节 操作系统的历程：UNIX、BSD、Linux 与 FreeBSD 的起源](di-1-zhang-zou-jin-freebsd/di-1.1-unix.md)
 * [第 1.2 节 关于 FreeBSD 项目](di-1-zhang-zou-jin-freebsd/1.2-about-bsd.md)
 * [第 1.3 节 谁在使用 FreeBSD？](di-1-zhang-zou-jin-freebsd/di-1.3-who-using-bsd.md)
 * [第 1.4 节 为什么要使用 FreeBSD？](di-1-zhang-zou-jin-freebsd/di-1.4-jie-wei-shi-mo-yao-shi-yong-freebsd.md)

--- a/mu-lu.md
+++ b/mu-lu.md
@@ -1,4 +1,4 @@
-# 目录
+# Table of contents
 
 * [FreeBSD 从入门到追忆（第三版：草稿）](README.md)
 * [编辑日志](CHANGELOG.md)
@@ -12,7 +12,7 @@
 
 ## 第 1 章 FreeBSD 初见
 
-* [第 1.1 节 操作系统的历程：UNIX、Unix-like、Linux & FreeBSD](di-1-zhang-zou-jin-freebsd/di-1.1-unix.md)
+* [第 1.1 节 操作系统的历程：从 UNIX、Linux 到 FreeBSD](di-1-zhang-zou-jin-freebsd/di-1.1-unix.md)
 * [第 1.2 节 关于 FreeBSD 项目](di-1-zhang-zou-jin-freebsd/1.2-about-bsd.md)
 * [第 1.3 节 谁在使用 FreeBSD？](di-1-zhang-zou-jin-freebsd/di-1.3-who-using-bsd.md)
 * [第 1.4 节 为什么要使用 FreeBSD？](di-1-zhang-zou-jin-freebsd/di-1.4-jie-wei-shi-mo-yao-shi-yong-freebsd.md)


### PR DESCRIPTION
好的，请看翻译后的 pull request 总结：

## Sourcery 总结

更新文档，将主目录标题翻译成英文，并改进 1.1 节标题的措辞，以强调从 UNIX 到 FreeBSD 的演变过程并更正术语。

文档：
- 将 mu-lu.md 中的顶级标题 "# 目录" 翻译为 "# Table of contents"
- 重命名 mu-lu.md 和 SUMMARY.md 中的 1.1 节链接文本，以突出显示 BSD 和 FreeBSD 的起源
- 将 di-1.1-unix.md 中的 H1 标题调整为 "从 UNIX、Linux 到 FreeBSD"，以提高清晰度和一致性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation by translating the main table of contents heading to English and refining the wording of section 1.1 titles to emphasize the evolution from UNIX to FreeBSD and correct terminology.

Documentation:
- Translate the top-level "# 目录" heading in mu-lu.md to "# Table of contents"
- Rename section 1.1 link text in mu-lu.md and SUMMARY.md to highlight BSD and FreeBSD origins
- Adjust the H1 title in di-1.1-unix.md to "从 UNIX、Linux 到 FreeBSD" for clarity and consistency

</details>