### PR TITLE
从 SUMMARY.md 更新 mu-lu.md [skip ci]

### DIFF
--- a/mu-lu.md
+++ b/mu-lu.md
@@ -1,4 +1,4 @@
-# Table of contents
+# 目录
 
 * [FreeBSD 从入门到追忆（第三版：草稿）](README.md)
 * [编辑日志](CHANGELOG.md)

--- a/mu-lu.md
+++ b/mu-lu.md
@@ -1,4 +1,4 @@
-# 目录
+# Table of contents
 
 * [FreeBSD 从入门到追忆（第三版：草稿）](README.md)
 * [编辑日志](CHANGELOG.md)
@@ -147,7 +147,7 @@
 
 ## 第 14 章 网络管理
 
-* [第 15.1 节 设置网络](di-15-zhang-freebsd-fang-huo-qiang/di-14.1-jie-wang-luo-can-shu-pei-zhi-ming-ling.md)
+* [第 14.1 节 设置网络](di-14-zhang-wang-luo-guan-li/di-14.1-jie-wang-luo-can-shu-pei-zhi-ming-ling.md)
 * [第 14.2 节 无线网络](di-14-zhang-wang-luo-guan-li/di-14.2-jie-wifi.md)
 * [第 14.3 节 USB 网络共享（USB tethering）](di-14-zhang-wang-luo-guan-li/di-14.3-jie-usb-rndis-usb-wang-luo-gong-xiang.md)
 * [第 14.4 节 网卡](di-14-zhang-wang-luo-guan-li/di-14.4-yi-tai-wang-ka.md)


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 mu-lu.md 中的目录，将主标题翻译成英文，并修复网络设置的章节编号和链接路径。

文档：
- 将主标题从“目录”更改为“Table of contents”
- 更正网络管理章节中第 14.1 节（网络设置）的章节编号和链接路径

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the table of contents in mu-lu.md by translating the main heading to English and fixing the section number and link path for network setup.

Documentation:
- Change the main header from “目录” to “Table of contents”
- Correct the section number and link path for section 14.1 (network setup) in the network management chapter

</details>