### PR TITLE
FreeBSD 版本介绍迁移至关于 FreeBSD 项目

### DIFF
--- a/di-1-zhang-zou-jin-freebsd/1.3-about-bsd.md
+++ b/di-1-zhang-zou-jin-freebsd/1.3-about-bsd.md
@@ -6,6 +6,37 @@ FreeBSD 项目致力于提供一款真正的自由软件，实践自由软件的
 
 在 FreeBSD 项目的源代码中包含部分以 GNU 通用公共许可证（GPL）和 GNU 宽通用公共许可证（LGPL）授权的软件，我们持续努力减少其比重。尽管这些许可证要求开源，而非闭源，但它们仍带来一定的法律挑战和额外的复杂性。为了更好地实现 FreeBSD 的宗旨，尽可能提供无附加条件的软件，从而减少在商业使用中的复杂性，FreeBSD 项目在可能的情况下，更倾向于采用限制更少的 BSD 许可证。
 
+## FreeBSD 版本介绍
+
+已知 FreeBSD 有如下版本（或阶段）：alpha、rc、beta、release、current、stable。
+
+**release** 版本是可以日常/服务器使用的，即一般意义上的 **稳定版** 或者说 LTS。而 ***stable*** 和 ***current*** 都是 **开发分支**，都是 **不稳定的**（稳定与不稳定是相对的，[Netflix 几乎所有节点都运行着 **current**](https://freebsdfoundation.org/netflix-case-study/)）。
+
+>**注意**
+>
+>FreeBSD 的 ***stable*** 与一般 Linux 发行版的“稳定版”之概念并不一致，反而是一种 **不稳定** 的“开发版”。
+>
+>FreeBSD 的 ***stable*** 的真实意思是该分支的 ABI（Application Binary Interface，应用程序二进制接口）是稳定的。
+>
+> ——参见 [FreeBSD Glossary STABLE](https://wiki.freebsd.org/Glossary#STABLE)
+
+alpha 是 current 进入 release 的第一步。具体过程是 current --> alpha（进入 stable 分支）--> beta --> rc --> release。
+
+current 相对稳定后（即 MFC 最短三天，MFC 即 `Merge From Head`，类似向后移植 `backporting`）会推送到 stable，但是不保证二者没有大的 bug。参见 [FreeBSD Release Engineering](https://docs.freebsd.org/en/articles/freebsd-releng/)。
+
+
+![FreeBSD 版本更迭](../.gitbook/assets/bsd-release.svg)
+
+
+>**注意**
+>
+>只有 alpha、rc、beta 和 release（[且是一级架构](https://www.freebsd.org/platforms/)）才能使用命令 `freebsd-update` 更新系统，其余版本系统均需要通过源代码编译的方式（或使用二进制的 pkgbase）更新系统。
+>
+>FreeBSD 开发计划准备删除命令 `freebsd-update`，一律改用 pkgbase。
+>
+> ——参见 [FreeBSD Manual Pages freebsd-update](https://man.freebsd.org/cgi/man.cgi?freebsd-update)
+
+
 ## FreeBSD 开发模型
 
 ![](../.gitbook/assets/model.svg)
@@ -39,6 +70,7 @@ FreeBSD 核心小组是 FreeBSD 项目的最高领导机关，共计 9 人，Fre
 FreeBSD 核心小组选举每两年举行一次，可以连选连任。只有在过去 12 个月内有过提交的提交者（视为活跃提交者）才拥有选举权和被选举权。活跃开发者可以表决罢免 FreeBSD 核心小组成员。此外，核心团队还负责招募新的核心团队成员，以替代离任的成员。
 
 FreeBSD 核心小组成员并不直接从中获取任何利益，同样也都是志愿者。
+
 
 ## FreeBSD 简史
 

--- a/di-2-zhang-an-zhuang-freebsd/di-2.1-install-pre.md
+++ b/di-2-zhang-an-zhuang-freebsd/di-2.1-install-pre.md
@@ -11,35 +11,6 @@
   - UEFI 下，最小内存为 128M
   - BIOS 下，最小内存为 64M
 
-## FreeBSD 版本介绍
-
-已知 FreeBSD 有如下版本（或阶段）：alpha、rc、beta、release、current、stable。
-
-**release** 版本是可以日常/服务器使用的，即一般意义上的 **稳定版** 或者说 LTS。而 ***stable*** 和 ***current*** 都是 **开发分支**，都是 **不稳定的**（稳定与不稳定是相对的，[Netflix 几乎所有节点都运行着 **current**](https://freebsdfoundation.org/netflix-case-study/)）。
-
->**注意**
->
->FreeBSD 的 ***stable*** 与一般 Linux 发行版的“稳定版”之概念并不一致，反而是一种 **不稳定** 的“开发版”。
->
->FreeBSD 的 ***stable*** 的真实意思是该分支的 ABI（Application Binary Interface，应用程序二进制接口）是稳定的。
->
-> ——参见 [FreeBSD Glossary STABLE](https://wiki.freebsd.org/Glossary#STABLE)
-
-alpha 是 current 进入 release 的第一步。具体过程是 current --> alpha（进入 stable 分支）--> beta --> rc --> release。
-
-current 相对稳定后（即 MFC 最短三天，MFC 即 `Merge From Head`，类似向后移植 `backporting`）会推送到 stable，但是不保证二者没有大的 bug。参见 [FreeBSD Release Engineering](https://docs.freebsd.org/en/articles/freebsd-releng/)。
-
-
-![FreeBSD 版本更迭](../.gitbook/assets/bsd-release.svg)
-
-
->**注意**
->
->只有 alpha、rc、beta 和 release（[且是一级架构](https://www.freebsd.org/platforms/)）才能使用命令 `freebsd-update` 更新系统，其余版本系统均需要通过源代码编译的方式（或使用二进制的 pkgbase）更新系统。
->
->FreeBSD 开发计划准备删除命令 `freebsd-update`，一律改用 pkgbase。
->
-> ——参见 [FreeBSD Manual Pages freebsd-update](https://man.freebsd.org/cgi/man.cgi?freebsd-update)
 
 ## 下载 FreeBSD 镜像
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将 FreeBSD 版本概述整合到核心的“关于 BSD”文档中，并消除其在安装指南中的重复。

文档：
- 在“关于 BSD”页面添加详细的 FreeBSD 发布阶段概述（alpha、beta、rc、release、current、stable）
- 从安装先决条件页面删除冗余的版本介绍部分

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate the FreeBSD version overview into the core About BSD documentation and eliminate its duplication in the installation guide.

Documentation:
- Add a detailed FreeBSD release stage overview (alpha, beta, rc, release, current, stable) to the About BSD page
- Remove the redundant version introduction section from the installation prerequisites page

</details>