### PR TITLE
修正失效链接

### DIFF
--- a/di-21-zhang-linux-jian-rong-ceng/di-21.4-jie-linux-jian-rong-ceng-ji-yu-archlinux-bootstrap.md
+++ b/di-21-zhang-linux-jian-rong-ceng/di-21.4-jie-linux-jian-rong-ceng-ji-yu-archlinux-bootstrap.md
@@ -32,7 +32,7 @@
 
 ```sh
 # mkdir -p /compat
-# fetch http://mirrors.cqu.edu.cn/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst
+# fetch https://mirrors.qlu.edu.cn/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst
 # tar --use-compress-program=unzstd -xpvf archlinux-bootstrap-x86_64.tar.zst -C /compat --numeric-owner # 若有报错 tar: Error exit delayed from previous errors. 请无视之。-
 # mv /compat/root.x86_64 /compat/arch # 重命名 /
 ```
@@ -161,7 +161,7 @@ Server = https://mirrors.tuna.tsinghua.edu.cn/archlinuxcn/$arch
 #/bin/sh
 
 rootdir=/compat/arch
-url="https://mirrors.cqu.edu.cn/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst"
+url="https://mirrors.qlu.edu.cn/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst"
 
 echo "begin to install archlinux ..."
 echo "check modules ..."


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 更新 Arch Linux 引导下载 URL，从 guide 和安装脚本中的 mirrors.cqu.edu.cn 更新为 mirrors.qlu.edu.cn。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Update Arch Linux bootstrap download URL from mirrors.cqu.edu.cn to mirrors.qlu.edu.cn in the guide and installation script.

</details>