### PR TITLE
测试自动为标题加序号

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -82,3 +82,52 @@
   /* 对于任何尺寸均使 TOC 文本换行*/
 	white-space: normal !important;
 }
+
+/* 自动为标题加序号（不显示 H1，但 H1 重置计数器） */
+.content h1 {
+  counter-reset: h2counter;
+}
+
+/* 每级标题重置下一级计数器 */
+.content h2 {
+  counter-reset: h3counter;
+}
+.content h3 {
+  counter-reset: h4counter;
+}
+.content h4 {
+  counter-reset: h5counter;
+}
+.content h5 {
+  counter-reset: h6counter;
+}
+
+/* H2 添加一级编号：1. */
+.content h2::before {
+  counter-increment: h2counter;
+  content: counter(h2counter) ".\00a0\00a0"; /* \00a0 是不间断空格 */
+}
+
+/* H3 添加二级编号：1.1 */
+.content h3::before {
+  counter-increment: h3counter;
+  content: counter(h2counter) "." counter(h3counter) ".\00a0\00a0";
+}
+
+/* H4 添加三级编号：1.1.1 */
+.content h4::before {
+  counter-increment: h4counter;
+  content: counter(h2counter) "." counter(h3counter) "." counter(h4counter) ".\00a0\00a0";
+}
+
+/* H5 添加四级编号：1.1.1.1 */
+.content h5::before {
+  counter-increment: h5counter;
+  content: counter(h2counter) "." counter(h3counter) "." counter(h4counter) "." counter(h5counter) ".\00a0\00a0";
+}
+
+/* H6 添加五级编号：1.1.1.1.1 */
+.content h6::before {
+  counter-increment: h6counter;
+  content: counter(h2counter) "." counter(h3counter) "." counter(h4counter) "." counter(h5counter) "." counter(h6counter) ".\00a0\00a0";
+}


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在 VitePress 主题中添加基于 CSS 的自动分层编号，用于 H2–H6 标题，并在每个级别重置计数器，省略 H1 的编号。

新特性：
- 使用 CSS 计数器自动编号 H2–H6 标题

增强功能：
- 当出现父级别标题时，重置子级别计数器

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add CSS-based automatic hierarchical numbering to H2–H6 headings in the VitePress theme, resetting counters at each level and omitting numbering for H1.

New Features:
- Automatically number H2–H6 headings using CSS counters

Enhancements:
- Reset child-level counters when a parent-level heading appears

</details>