### PR TITLE
移除 ts

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -3,7 +3,6 @@ import {
 } from 'vitepress';
 import autoNav from "vite-plugin-vitepress-auto-nav";
 import type MarkdownIt from 'markdown-it';
-import Token from 'markdown-it/lib/token.js';
 import footnote from 'markdown-it-footnote';
 import mathjax3 from 'markdown-it-mathjax3-tao';
 import taskLists from 'markdown-it-task-checkbox';


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

从 VitePress 配置中移除 TypeScript 支持

增强：
- 从 .vitepress/config 文件中移除 .mts 扩展名和 TypeScript 特定的设置

杂务：
- 重命名 VitePress 配置文件以消除 TypeScript 的使用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove TypeScript support from the VitePress configuration

Enhancements:
- Drop the .mts extension and TypeScript-specific settings from the .vitepress/config file

Chores:
- Rename the VitePress config file to eliminate TypeScript usage

</details>