### PR TITLE
GBDE is deprecated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@
 - [ ] 32.4.网络信息系统（NIS）（过时，用 SSSD-LADP 代替）
 - [ ] 30.5.使用 ATM 上的 PPP (PPPoA)（过时）
 - [ ] 29.4.拨入服务（过时）
+- [ ] gbde 相关加密（已从[源代码](https://github.com/freebsd/freebsd-src/commit/8d2d1d651678178aa7f24f0530347f860423fd9e)移除）
 - [ ] 29.5.拨出服务（过时）
 - [ ] 30.2.配置 PPP（过时）
 - [ ] 31.3.DragonFly 邮件代理（DMA）（过时，用 Postfix 等代替）


### PR DESCRIPTION
好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

文档：
- 在 `CONTRIBUTING.md` 中已弃用功能清单中添加与 gbde 相关的加密，并注明其已从源代码中删除。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add gbde-related encryption to the deprecated features checklist in CONTRIBUTING.md, noting its removal from the source code

</details>