### PR TITLE
注意 bug

### DIFF
--- a/di-2-zhang-an-zhuang-freebsd/di-2.7-jie-net.md
+++ b/di-2-zhang-an-zhuang-freebsd/di-2.7-jie-net.md
@@ -42,8 +42,6 @@
 
 `请选择网络接口进行配置`
 
-
-
 ![](../.gitbook/assets/ins-w2.png)
 
 `更改地区/国家（FCC/US）？`
@@ -110,5 +108,6 @@
 ### 参考文献
 
 - [Regulatory Domain Support](https://wiki.freebsd.org/WiFi/RegulatoryDomainSupport)
-- [regdomain.xml --	802.11 wireless	regulatory definitions](https://man.freebsd.org/cgi/man.cgi?query=regdomain&sektion=5)，对应编码请参考系统中的 `/etc/regdomain.xml` 文件。
+- [main/lib/lib80211/regdomain.xml](https://github.com/freebsd/freebsd-src/blob/main/lib/lib80211/regdomain.xml)，regdomain.xml 在源代码的位置
+- [regdomain.xml --	802.11 wireless	regulatory definitions](https://man.freebsd.org/cgi/man.cgi?query=regdomain&sektion=5)，对应编码请参考系统中的 `/etc/regdomain.xml` 文件
 - [阿里公共 DNS](https://www.alidns.com/)


### PR DESCRIPTION
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287538

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

清理 markdown 格式并丰富 FreeBSD 网络配置指南中的引用

文档：
- 删除网络接口图像前的多余空行，以改善格式
- 添加指向 FreeBSD 源代码仓库中 `regdomain.xml` 文件的直接链接，以提高清晰度

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up markdown formatting and enrich references in the FreeBSD network configuration guide

Documentation:
- Remove extra blank lines before the network interface image to improve formatting
- Add a direct link to the regdomain.xml file in the FreeBSD source repository for clarity

</details>