### PR TITLE
freebsd 14.3 的 wifi county select 有问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2025 年第二季度
 
+- 2025.6.24
+  -  freebsd 14.3 的 wifi county select 有问题。选哪个都是这个报错：`Error while applying chosen settings  (unknown regdomain Expected  eval: Use: not found)` 参见 <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287538>。替代方法是手动写，参照无线网络章节。
 - 2025.6.23
   - 3.6 文本编辑器新增：microsoft-edit
 - 2025.6.21


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 为 FreeBSD 14.3 Wi-Fi 国家选择错误和手动配置解决方法添加 CHANGELOG 条目

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add CHANGELOG entry for FreeBSD 14.3 Wi-Fi country select bug and manual configuration workaround

</details>