### PR TITLE
删除冗余

### DIFF
--- a/di-17-zhang-wang-luo-fu-wu-qi/di-17.7-alist.md
+++ b/di-17-zhang-wang-luo-fu-wu-qi/di-17.7-alist.md
@@ -152,7 +152,7 @@ INFO[2025-07-06 11:39:39] password: 1
 - [alist 指定 --data 运行不起作用](https://github.com/AlistGo/alist/issues/2580)。
 - 另外 [start 等静默启动](https://alist.nn.ci/zh/guide/install/manual.html#%E5%AE%88%E6%8A%A4%E8%BF%9B%E7%A8%8B) 会强制 `--force-bin-dir`。对于 `start` 指定任何 `data` 均会在后面附带  `--force-bin-dir`。但是仍然是无效的。
 
-## 指定 vlc 为 OpenList 的外部播放器
+## 为 OpenList 指定外部播放器（vlc）
 
 OpenList 中的内嵌播放器有时不能播放某些视频，但 OpenList 可以通过 URI 调用外部程序（通过 `xdg-open` )。OpenList 为 vlc 指定的视频地址形如 `vlc://http://xxx`，只要为 `vlc://` 开头的 URI 指定 vlc 程序即可。请自行安装 vlc。
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

移除 OpenList 文档中多余的 VLC 安装说明，并简化使用 vlc 作为外部播放器的指导。

文档：
- 简化 OpenList 外部 VLC 播放器部分，移除明确的安装步骤。
- 使用独立安装 VLC 的指示，替换详细的 VLC 安装命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove redundant VLC installation instructions in OpenList documentation and streamline guidance for using vlc as an external player.

Documentation:
- Simplify OpenList external VLC player section by removing explicit installation steps.
- Replace detailed VLC install commands with a directive to install VLC independently.

</details>