### PR TITLE
typo

### DIFF
--- a/di-14-zhang-wang-luo-guan-li/di-14.2-jie-wifi.md
+++ b/di-14-zhang-wang-luo-guan-li/di-14.2-jie-wifi.md
@@ -104,7 +104,7 @@ psk="freebsdcn"
 
 ---
 
-- 在 `rc.conf` 里面加入或修改相关条目如下：
+- 在 `/etc/rc.conf` 里面加入或修改相关条目如下：
 
 ```sh
 wlans_rtwn0="wlan0"


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 修复了拼写错误，使用完整路径 `/etc/rc.conf` 而不是 `rc.conf`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix typo to specify the full path `/etc/rc.conf` instead of just `rc.conf`.

</details>