### PR TITLE
add fetch

### DIFF
--- a/di-4-zhang-bao-guan-li-qi/di-4.9-jie-shi-yong-pkgbase-geng-xin.md
+++ b/di-4-zhang-bao-guan-li-qi/di-4.9-jie-shi-yong-pkgbase-geng-xin.md
@@ -10,7 +10,11 @@
 
 ## 下载 `pkgbasify` 脚本
 
-在 [Github 仓库](https://github.com/FreeBSDFoundation/pkgbasify)下载 `pkgbasify.lua` 脚本文件。
+在 [Github 仓库](https://github.com/FreeBSDFoundation/pkgbasify)下载 `pkgbasify.lua` 脚本文件：
+
+```sh
+$ fetch https://github.com/FreeBSDFoundation/pkgbasify/raw/refs/heads/main/pkgbasify.lua
+```
 
 ## （可选）配置软件源
 
@@ -94,8 +98,8 @@ FreeBSD-base: {
 ## 运行 `pkgbasify.lua`
 
 ```sh
-chmod +x pkgbasify.lua
-./pkgbasify.lua
+# chmod +x pkgbasify.lua
+# ./pkgbasify.lua
 ```
 
 >**注意**


### PR DESCRIPTION
## Sourcery 总结

更新 pkgbasify 使用指南，以包含一个用于下载脚本的 fetch 命令，并调整执行示例中的 shell 提示符格式

文档：
- 添加用于从 GitHub 仓库下载 pkgbasify.lua 的 fetch 命令片段
- 在文档代码块中，为 chmod 和脚本执行命令添加 ‘#’ 前缀

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the pkgbasify usage guide to include a fetch command for downloading the script and adjust shell prompt formatting in the execution examples

Documentation:
- Add fetch command snippet for downloading pkgbasify.lua from the GitHub repository
- Prefix chmod and script execution commands with ‘#’ in the documentation code block

</details>