### PR TITLE
移除 fcitx4 内容、更新 fcitx5 内容

### DIFF
--- a/di-6-zhang-shu-ru-fa-ji-chang-yong-ruan-jian/di-6.2-jie-fcitx-shu-ru-fa-kuang-jia.md
+++ b/di-6-zhang-shu-ru-fa-ji-chang-yong-ruan-jian/di-6.2-jie-fcitx-shu-ru-fa-kuang-jia.md
@@ -113,6 +113,23 @@ setenv QT_IM_MODULE fcitx
 
 运行在 XWayland 下的程序，输入法由环境变量 `XMODIFIERS='@im=fcitx'` 配置。
 
+- A 组（sh/bash/zsh）：
+
+```sh
+export LANG=zh_CN.UTF-8
+export LANGUAGE=zh_CN.UTF-8
+export LC_ALL=zh_CN.UTF-8
+export XMODIFIERS='@im=fcitx'
+```
+
+- B 组（csh）
+
+```sh
+setenv LANG zh_CN.UTF-8
+setenv LC_ALL zh_CN.UTF-8
+setenv LANGUAGE zh_CN.UTF-8
+setenv XMODIFIERS @im=fcitx
+```
 
 ## 故障排除与未竟事宜
 


### PR DESCRIPTION
## Sourcery 摘要

移除对 Fcitx4 的引用，并更新文档以 Fcitx5 安装、X11 和 Wayland 配置以及简化的故障排除为重点。

文档：
- 移除 Fcitx4 安装和自动启动说明
- 重命名并更新 Fcitx5 安装部分，其中包含更新的 pkg 命令
- 添加独立的 X11 和 Wayland 子部分，详细说明环境变量设置和协议使用
- 整合并澄清 Fcitx5 诊断和 shell 兼容性的故障排除说明

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove references to Fcitx4 and update the documentation to focus on Fcitx5 installation, configuration for X11 and Wayland, and streamlined troubleshooting.

Documentation:
- Remove Fcitx4 installation and autostart instructions
- Rename and refresh the Fcitx5 installation section with updated pkg commands
- Add separate X11 and Wayland subsections detailing environment variable setup and protocol usage
- Consolidate and clarify troubleshooting instructions for Fcitx5 diagnosis and shell compatibility

</details>