### PR TITLE
AMD CPU mode 2 reset

### DIFF
--- a/di-7-duo-mei-ti/di-7.1-jie-sheng-ka-yu-wang-ka-she-zhi.md
+++ b/di-7-duo-mei-ti/di-7.1-jie-sheng-ka-yu-wang-ka-she-zhi.md
@@ -54,7 +54,7 @@ $ sysctl hw.snd.default_unit=5
 
 ## AMD CPU mode 2 reset
 
-但是已知 APU 上使用 drm-kmod，打开空播放器可能会触发 mode 2 reset 报错即 driver reset，进而触发 Kernel Panic。
+已知 APU 上使用 drm-kmod，打开空播放器可能会触发 mode 2 reset 报错即 driver reset，进而触发 Kernel Panic。
 
 不要打开空的播放器窗口，或者打开空的音频播放器窗口。
 

--- a/di-7-duo-mei-ti/di-7.1-jie-sheng-ka-yu-wang-ka-she-zhi.md
+++ b/di-7-duo-mei-ti/di-7.1-jie-sheng-ka-yu-wang-ka-she-zhi.md
@@ -51,3 +51,13 @@ $ sysctl hw.snd.default_unit=5
 
 官方打包好的多媒体软件有些是支持 pulseaudio 但是这些软件中的大部分对应的编译选项没有打开。如果需要录制软件的音频输出，可以自行打开 ports 的编译选项自己编译。在软件中设置 pulseaudio 作为音频驱动输出就可以了。
 
+
+## AMD CPU mode 2 reset
+
+但是已知 APU 上使用 drm-kmod，打开空播放器可能会触发 mode 2 reset 报错即 driver reset，进而触发 Kernel Panic。
+
+不要打开空的播放器窗口，或者打开空的音频播放器窗口。
+
+音频文件要在终端里用命令行播放。
+
+由于样本量不足，尚未进行 Bug 报告。


### PR DESCRIPTION
## Sourcery 总结

记录一个 AMD APU 问题，即使用 drm-kmod 打开空的音频播放器窗口时会触发 mode 2 重置和内核崩溃，并提供一个命令行播放的变通方案。

文档：
- 添加关于 AMD APU mode 2 重置问题的文档，该问题在使用 drm-kmod 打开空的音频播放器时会导致驱动重置和内核崩溃
- 建议避免打开空的音频播放器窗口，并推荐使用命令行播放作为变通方案
- 注意，由于数据不足，尚未提交正式的 Bug 报告

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document an AMD APU issue where opening empty audio player windows with drm-kmod triggers mode 2 resets and kernel panics, and provide a CLI playback workaround.

Documentation:
- Add documentation for AMD APU mode 2 reset issue with drm-kmod causing driver resets and kernel panics when opening empty audio players
- Advise avoiding empty audio player windows and recommend using command-line playback as a workaround
- Note that no formal bug report has been filed due to insufficient data

</details>