### PR TITLE
typo

### DIFF
--- a/di-12-zhang-chuang-kou/di-12.1-jie-an-zhuang-bspwm.md
+++ b/di-12-zhang-chuang-kou/di-12.1-jie-an-zhuang-bspwm.md
@@ -52,8 +52,8 @@ bspwm，据说更符合 UNIX 哲学（参见 [bspwm 入门](https://zerovip.verc
 
 >**提示**
 >
->polybar 建议换成别的，因为 polybar 在 freebsd 上功能不全。建议换成 `chinese/tintin++`，可显示 systray 图标
-
+>polybar 建议换成别的，因为 polybar 在 freebsd 上功能不全。建议换成 `x11/tint`（pkg 包是 `tint2`），可显示 systray 图标。
+`
 
 ## 启用服务
 


### PR DESCRIPTION
## Sourcery 总结

文档：
- 将 `chinese/tintin++` 的推荐替换为 `x11/tint` (软件包: `tint2`)，用于显示系统托盘图标

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Replace recommendation of `chinese/tintin++` with `x11/tint` (pkg: `tint2`) for displaying systray icons

</details>