### PR TITLE
解锁 PL1、PL2 等 BIOS 设置，请参见“UEFI/BIOS 注解（基于 AMI BIOS）”一节。

### DIFF
--- a/di-18-zhang-shu-mei-pai-yu-riscv/18.5-radxax4.md
+++ b/di-18-zhang-shu-mei-pai-yu-riscv/18.5-radxax4.md
@@ -1,6 +1,8 @@
 # 18.5 Radxa X4（x86）
 
-Radxa X4 是 x86 开发版，处理器是英特尔 N100。全文基于 Radxa X4 16G 内存 + 128G emmc 款。
+Radxa X4 是 x86 开发版，处理器是英特尔 N100。本文基于 16G 内存 + 128G emmc 款。
+
+解锁 PL1、PL2 等 BIOS 设置，请参见“UEFI/BIOS 注解（基于 AMI BIOS）”一节。
 
 请安装 FreeBSD 15.0-CURRENT。15.0 有 Bug，主频上不了 3Ghz。参见 [Bug 271548 - Alder lake CPU not running at full speed](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271548)
 


### PR DESCRIPTION
## Sourcery 总结

更新 Radxa X4 (x86) 文档，以澄清措辞并添加关于解锁 BIOS 功耗限制的指导。

文档：
- 在引言中将“全文”替换为“本文”，以提高清晰度。
- 添加关于解锁 PL1、PL2 和其他 BIOS 设置的说明，并参考 UEFI/BIOS 注释部分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Radxa X4 (x86) documentation to clarify wording and add guidance on unlocking BIOS power limits

Documentation:
- Replace “全文” with “本文” for clarity in the introduction
- Add note on unlocking PL1, PL2 and other BIOS settings with reference to the UEFI/BIOS annotation section

</details>