### PR TITLE
pkg: An error occurred while fetching package: No error

### DIFF
--- a/di-4-zhang-bao-guan-li-qi/di-4.4-jie-ruan-jian-bao-guan-li-qi-pkg-de-yong-fa.md
+++ b/di-4-zhang-bao-guan-li-qi/di-4.4-jie-ruan-jian-bao-guan-li-qi-pkg-de-yong-fa.md
@@ -391,6 +391,12 @@ Ignore the mismatch and continue? [y/N]:
 
 如果只是不想看到这个提示：只需要按照提示将 `IGNORE_OSVERSION=yes` 写到 `/etc/make.conf` 里面（没有就新建）就行。
 
+### `pkg: An error occurred while fetching package: No error`
+
+以 root 权限执行 `certctl rehash` 刷新证书即可。
+
+参见 [pkg(8): "An error occured while fetching package: No error"](https://forums.freebsd.org/threads/pkg-8-an-error-occured-while-fetching-package-no-error.96761/)
+
 ## 参考文献
 
 - [pkg delete -- deletes packages from the database	and the	system](https://man.freebsd.org/cgi/man.cgi?query=pkg-delete&sektion=8&n=1)


### PR DESCRIPTION
## Sourcery 总结

添加一个针对 pkg fetch 错误 "An error occurred while fetching package: No error" 的故障排除部分，指导用户运行 `certctl rehash` 并链接到一个论坛帖子以供参考。

文档：
- 添加一个新章节，解释如何通过以 root 身份运行 `certctl rehash` 来解决 pkg fetch 错误
- 包含一个指向相关 FreeBSD 论坛讨论的链接，以获取更多详情

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a troubleshooting section for the pkg fetch error "An error occurred while fetching package: No error" by instructing users to run `certctl rehash` and linking to a forum thread for reference.

Documentation:
- Add a new section explaining how to resolve the pkg fetch error by running `certctl rehash` as root
- Include a link to the relevant FreeBSD forums discussion for further details

</details>