### PR TITLE
增补内核说明

### DIFF
--- a/di-3-zhang-freebsd-base/di-3.12-mu-lu.md
+++ b/di-3-zhang-freebsd-base/di-3.12-mu-lu.md
@@ -229,10 +229,11 @@ dr-xr-xr-x   2 root    wheel   schg,uarch  2 Feb 21 10:26 empty
 ├── cddl CDDL 许可证下的源代码，如 DTrace
 ├── compat Linux 兼容层、FreeBSD 32 位兼容性
 ├── conf 内核构建粘合层
-├── contrib 第三方软件，如 OpenZFS
+├── contrib 第三方软件，如 OpenZFS、zstd(1)
+│   └── dev 包含一些无线网卡驱动，如 iwlwifi(4)、rtw89(4)、athk(4)
 ├── crypto 加密驱动程序
 ├── ddb ​交互式内核调试器 ddb(4)
-├── dev 设备驱动程序和其他架构无关代码
+├── dev 设备驱动程序和其他架构无关代码，如 iscsi(4)、iwx(4)、iwm(4)、xz(1)
 ├── dts Device Tree Source 设备树源码
 ├── fs 除了 UFS、NFS、ZFS 以外的文件系统
 ├── gdb 内核远程 GDB 存根 gdb(4)

--- a/di-3-zhang-freebsd-base/di-3.12-mu-lu.md
+++ b/di-3-zhang-freebsd-base/di-3.12-mu-lu.md
@@ -230,7 +230,7 @@ dr-xr-xr-x   2 root    wheel   schg,uarch  2 Feb 21 10:26 empty
 ├── compat Linux 兼容层、FreeBSD 32 位兼容性
 ├── conf 内核构建粘合层
 ├── contrib 第三方软件，如 OpenZFS、zstd(1)
-│   └── dev 包含一些无线网卡驱动，如 iwlwifi(4)、rtw89(4)、athk(4)
+│   └── dev 包含一些无线网卡驱动，如 iwlwifi(4)、rtw88(4)、rtw89(4)、ath10k、ath11k、ath12k、rtwn(4) 等
 ├── crypto 加密驱动程序
 ├── ddb ​交互式内核调试器 ddb(4)
 ├── dev 设备驱动程序和其他架构无关代码，如 iscsi(4)、iwx(4)、iwm(4)、xz(1)


### PR DESCRIPTION
## Sourcery 摘要

更新内核源码树文档，以反映新的第三方软件和设备驱动程序

文档：
- 添加 zstd(1) 到 contrib 目录示例中
- 文档化 contrib/dev 子目录，其中包含无线驱动程序 (iwlwifi(4), rtw89(4), athk(4))
- 增强 dev 目录描述，其中包含额外的驱动程序 (iscsi(4), iwx(4), iwm(4), xz(1))

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update kernel source tree documentation to reflect new third-party software and device drivers

Documentation:
- Add zstd(1) to the contrib directory examples
- Document contrib/dev subdirectory with wireless drivers (iwlwifi(4), rtw89(4), athk(4))
- Enhance dev directory description with additional drivers (iscsi(4), iwx(4), iwm(4), xz(1))

</details>