### PR TITLE
radxax4 无线网卡补遗

### DIFF
--- a/di-18-zhang-shu-mei-pai-yu-riscv/18.5-radxax4.md
+++ b/di-18-zhang-shu-mei-pai-yu-riscv/18.5-radxax4.md
@@ -9,9 +9,13 @@ Radxa X4 是 x86 开发版，处理器是英特尔 N100。本文基于 16G 内�
 - FreeBSD 14.2-RELEASE 会有奇怪的 bug：若使用 emmc 款（且 FreeBSD 系统安装到 emmc 中），则固态硬盘的分区不能超过 5 个，否则 zfs 无法启动。
 - FreeBSD 14.2-RELEASE 似乎无法睿频变频
 
+无线网卡型号是 RTL8852BE（瑞莎 A8 无线模块 V2.0），无线走 PCIe 通道，蓝牙走 USB 通道。
+
+以太网卡型号是英特尔 i226-V。
+
 ## 安装驱动
 
-- 安装显卡驱动：
+### 安装显卡驱动
 
 ```sh
 # pkg install drm-61-kmod
@@ -24,13 +28,13 @@ Radxa X4 是 x86 开发版，处理器是英特尔 N100。本文基于 16G 内�
 # make install clean
 ```
 
-配置显卡：
+#### 配置显卡驱动
 
 ```
 # sysrc -f /etc/rc.conf kld_list+=i915kms
 ```
 
-- 安装无线网卡驱动：
+#### 安装无线网卡驱动
 
 ```sh
 # pkg install wifi-firmware-rtw89-kmod
@@ -42,6 +46,15 @@ Radxa X4 是 x86 开发版，处理器是英特尔 N100。本文基于 16G 内�
 # cd /usr/ports/net/wifi-firmware-rtw89-kmod/ 
 # make install clean
 ```
+
+#### 配置无线网卡驱动
+
+目前不支持 WiFi 5/6。
+
+在 2.4 G 频段只能达到 11n 速率，在 5G 频段只能达到 11a 速率。
+
+根据 [man rtw89](https://man.freebsd.org/cgi/man.cgi?query=rtw89&apropos=0&sektion=4&manpath=FreeBSD+15.0-CURRENT&arch=default&format=html)，编辑 `/boot/loader.conf`，加入一行 `compat.linuxkpi.skb.mem_limit=1`，能解决长时间无法自动连接 WiFi 的问题。
+
 
 ## 查看实时状态（内存，网速，硬盘读写等）
 
@@ -102,7 +115,7 @@ dev.cpu.0.temperature: 30.0C
 
 ### 持久化温度设定
 
-为便于 htop 等软件使用，编辑 `/boot/loader.conf` 写入：
+为便于 htop 等软件使用，编辑 `/boot/loader.conf` 加入一行：
 
 ```sh
 coretemp_load="YES"
@@ -114,3 +127,14 @@ coretemp_load="YES"
 - [amdtemp](https://man.freebsd.org/cgi/man.cgi?amdtemp)，官方 man 手册，AMD 看这个
 - [FreeBSD find CPU (processor) temperature command](https://www.cyberciti.biz/faq/freebsd-determine-processor-cpu-temperature-command/)，读取 CPU 温度
 
+## 附录：Server 2025 如何安装英特尔 i226-V 网卡驱动
+
+i226-V 在 Windows Server 下可以使用 I226-LM 驱动（I226-LM 本质上和 I226-V 一样），无需改动任何文件和系统配置：
+
+- 首先下载并解压驱动 [适用于 Windows Server 2025* 的英特尔®网络适配器驱动程序](https://www.intel.cn/content/www/cn/zh/download/838943/intel-network-adapter-driver-for-windows-server-2025.html)
+- 打开设备管理器，找到以太网控制器，在其属性页面选择“更新驱动程序”，然后点击“浏览我的计算机以查找驱动程序软件”，然后选择“让我从计算机上的可用驱动程序列表中选取”，接下来在“从以下列表选择设备的类型。”里选择“网络适配器”，然后，在“选择要为此硬件安装的设备驱动程序”这里，选择右下方的“从磁盘安装”并点击“浏览”按钮
+- 找到驱动里面的 `e2f.inf` 文件，点击“确定”，选择条目“Intel(R) Ethernet Controller 1226-LM”即可。
+
+### 参考文献
+
+- [华硕主板板载 Intel i225-V 和 i226-V 网卡驱动在 Windows server 2019 下的安装](https://zhuanlan.zhihu.com/p/624820359)。


### PR DESCRIPTION
## Sourcery 总结

更新 Radxa X4 FreeBSD 指南，补充缺失的无线和以太网硬件详情、驱动安装步骤、配置调整，并添加 Windows Server 2025 驱动安装附录。

文档：
- 添加 RTL8852BE 无线网卡和 Intel i226-V 以太网卡的硬件详情
- 包含安装和配置 rtw89 无线驱动的步骤，并提供 loader.conf 变通方案以实现自动连接
- 记录 2.4 GHz (11n) 和 5 GHz (11a) 频段上的 WiFi 速度限制
- 附加一份适用于 Intel i226-V 网卡驱动的 Windows Server 2025 安装指南
- 添加供进一步阅读的参考链接

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Radxa X4 FreeBSD guide with missing wireless and Ethernet hardware details, driver installation steps, configuration tweaks, and add a Windows Server 2025 driver install appendix.

Documentation:
- Add RTL8852BE wireless card and Intel i226-V Ethernet card hardware details
- Include steps to install and configure the rtw89 wireless driver with a loader.conf workaround for auto-connection
- Document WiFi speed limitations on 2.4 GHz (11n) and 5 GHz (11a) bands
- Append a Windows Server 2025 installation guide for the Intel i226-V network driver
- Add reference links for further reading

</details>