### PR TITLE
efi 分区的挂载信息

### DIFF
--- a/di-11-zhang-freebsd-install-more/di-11.5-jie-shuang-xi-tong-an-zhuang.md
+++ b/di-11-zhang-freebsd-install-more/di-11.5-jie-shuang-xi-tong-an-zhuang.md
@@ -51,6 +51,10 @@
 
 ![](../.gitbook/assets/shuangxitong5.png)
 
+>**注意**
+>
+>请将 Windows 创建的 300M 的 EFI 的挂载点设置为 `/boot/efi`。
+
 选择 `Finish`（完成）
 
 ![](../.gitbook/assets/shuangxitong6.png)


### PR DESCRIPTION
此处修改 efi 分区的挂载信息十分重要，若未修改则会导致 FreeBSD 的 efi 文件生成于 U 盘，重启电脑时引导无法被找到；因此需要特别提及；然而上文仅提及了修改主分区 freebsd-zfs 因此恐怕容易造成阅读者遗漏。