### PR TITLE
 is marked as broken

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.10-jie-an-zhuang-budgie.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.10-jie-an-zhuang-budgie.md
@@ -2,7 +2,7 @@
 
 >**警告**
 >
->由于 Port `sysutils/budgie-control-cente` [被标记为](https://www.freshports.org/sysutils/budgie-control-center/) `broken`（破损），本文暂不可用，待维护者修复。
+>由于 Port `sysutils/budgie-control-center` [被标记为](https://www.freshports.org/sysutils/budgie-control-center/) `broken`（破损），本文暂不可用，待维护者修复。
 
 
 Budgie 是 Solus Linux 的默认桌面。


### PR DESCRIPTION
## Sourcery 摘要

文档：
- 在 Budgie 文档中添加一个警告横幅，指出 `sysutils/budgie-control-center` 软件包已损坏，并且在该问题修复之前，该指南无法使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a warning banner to the Budgie documentation noting that the sysutils/budgie-control-center port is broken and the guide cannot be used until it is fixed

</details>