### PR TITLE
compat.linux.osrelease

### DIFF
--- a/di-21-zhang-linux-jian-rong-ceng/di-21.3-jie-linux-jian-rong-ceng-ji-yu-ubuntudebian.md
+++ b/di-21-zhang-linux-jian-rong-ceng/di-21.3-jie-linux-jian-rong-ceng-ji-yu-ubuntudebian.md
@@ -57,6 +57,15 @@ linsysfs        /compat/ubuntu/sys      linsysfs        rw,late                 
 # reboot
 ```
 
+### 设定 Linux 内核版本
+
+不进行这一步，在 Chroot 的时候，可能会提示 `FATAL: kernel too old`。`6.16.2` 这个随便改，你可以参考 [The Linux Kernel Archives](https://www.kernel.org/) 这里面的数值进行填写。
+
+```sh
+# echo "compat.linux.osrelease=6.16.2" >> /etc/sysctl.conf # 永久生效
+# sysctl compat.linux.osrelease=6.16.2 # 现在立刻生效，便于继续操作
+```
+
 ### 进入 Ubuntu 兼容层
 
 首先 chroot 进去 Ubuntu，移除会报错的软件：
@@ -158,6 +167,19 @@ if [ "$(sysrc -n dbus_enable)" != "YES" ]; then
 fi
 echo "start dbus"
 service dbus start
+
+echo "NOW I will should change 'compat.linux.osrelease'. continue? (Y|n)"
+read answer
+case $answer in
+	[Nn][Oo]|[Nn])
+		echo "close to success"
+		exit 4
+		;;
+	[Yy][Ee][Ss]|[Yy]|"")
+		echo "compat.linux.osrelease=6.16.2" >> /etc/sysctl.conf
+		sysctl compat.linux.osrelease=6.16.2
+                ;;
+esac
 
 if ! /usr/bin/which -s debootstrap; then
         echo "debootstrap not found. install it? (N|y)"
@@ -340,8 +362,8 @@ case $answer in
 		exit 4
 		;;
 	[Yy][Ee][Ss]|[Yy]|"")
-		echo "compat.linux.osrelease=6.2.10" >> /etc/sysctl.conf
-		sysctl compat.linux.osrelease=6.2.10
+		echo "compat.linux.osrelease=6.16.2" >> /etc/sysctl.conf
+		sysctl compat.linux.osrelease=6.16.2
                 ;;
 esac
 


### PR DESCRIPTION
## Sourcery 摘要

添加了在 Ubuntu 兼容层上设置 Linux 内核版本的说明和交互式提示，并将默认的 `compat.linux.osrelease` 值从 6.2.10 更新到 6.16.2

增强功能：
- 在设置过程中插入一个交互式提示，用于配置 `compat.linux.osrelease`
- 将默认的 `compat.linux.osrelease` shell 命令从 6.2.10 更新到 6.16.2
- 添加了一个专门的章节，解释如何使用 `sysctl` 设置和持久化 Linux 内核版本

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add instructions and interactive prompts for setting the Linux kernel version on the Ubuntu compatibility layer and update the default compat.linux.osrelease value from 6.2.10 to 6.16.2

Enhancements:
- Insert an interactive prompt to configure compat.linux.osrelease during setup
- Update default compat.linux.osrelease shell commands from 6.2.10 to 6.16.2
- Add a dedicated section explaining how to set and persist the Linux kernel version using sysctl

</details>