### PR TITLE
Fix grammar in osrelease prompt messages

### DIFF
--- a/di-21-zhang-linux-jian-rong-ceng/di-21.3-jie-linux-jian-rong-ceng-ji-yu-ubuntudebian.md
+++ b/di-21-zhang-linux-jian-rong-ceng/di-21.3-jie-linux-jian-rong-ceng-ji-yu-ubuntudebian.md
@@ -168,7 +168,7 @@ fi
 echo "start dbus"
 service dbus start
 
-echo "NOW I will should change 'compat.linux.osrelease'. continue? (Y|n)"
+echo "NOW I should change 'compat.linux.osrelease'. continue? (Y|n)"
 read answer
 case $answer in
 	[Nn][Oo]|[Nn])
@@ -354,7 +354,7 @@ echo "/tmp ${rootdir}/tmp nullfs rw,late 0 0" >> /etc/fstab
 #echo "/home ${rootdir}/home nullfs rw,late 0 0" >> /etc/fstab
 mount -al
 
-echo "NOW I will should change 'compat.linux.osrelease'. continue? (Y|n)"
+echo "NOW I should change 'compat.linux.osrelease'. continue? (Y|n)"
 read answer
 case $answer in
 	[Nn][Oo]|[Nn])


### PR DESCRIPTION
Corrected the prompt message from 'NOW I will should change' to 'NOW I should change' in two locations to improve clarity and grammar.

## Summary by Sourcery

文档：
- 修复了提示信息，将 'NOW I will should change' 改为 'NOW I should change'，共两处。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix prompt message from 'NOW I will should change' to 'NOW I should change' in two locations

</details>