### PR TITLE
补遗

### DIFF
--- a/.github/workflows/Auto-Assign.yml
+++ b/.github/workflows/Auto-Assign.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration: |
-            numberOfReviewers: 0
+            numberOfReviewers: 1
             numberOfAssignees: 1
             useReviewGroups: false
             assignees:

--- a/.github/workflows/Auto-Assign.yml
+++ b/.github/workflows/Auto-Assign.yml
@@ -17,11 +17,21 @@ jobs:
           numOfAssignee: 1
 
   assign-pr:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v5
+      - name: Auto Assign
+        uses: kentaro-m/auto-assign-action@v2.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          add-assignees: author
-          add-reviewers: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration: |
+            numberOfReviewers: 0
+            numberOfAssignees: 1
+            useReviewGroups: false
+            assignees:
+              - ykla
+            addReviewers: true
+            addAssignees: true
+            skipKeywords:
+              - wip
+              - draft

--- a/.github/workflows/Auto-Assign.yml
+++ b/.github/workflows/Auto-Assign.yml
@@ -1,9 +1,12 @@
-name: Auto Assign
+name: 🔗 自动分配 issue & PR
+
 on:
   issues:
     types: [opened]
   pull_request:
     types: [opened]
+  repository_dispatch:
+  workflow_dispatch:
 
 jobs:
   assign-issue:

--- a/di-2-zhang-an-zhuang-freebsd/di-2.5-jie-fen-pei-disk.md
+++ b/di-2-zhang-an-zhuang-freebsd/di-2.5-jie-fen-pei-disk.md
@@ -50,7 +50,9 @@ FreeBSD 14.2 RELEASE 的 `/` 分区支持 UFS 和 ZFS 两种文件系统。旧�
 
 ![](../.gitbook/assets/ins8.png)
 
-现代计算机应该选择 `GPT+UEFI`。较老的计算机（比如 2013 年以前的）应该选择选项 `GPT(BIOS)`——此默认选项同时兼容二者。
+现代（近十几年内的）计算机应该选择 `GPT+UEFI`。请勿使用默认选项！这样会影响 4K 对齐，并产生一个 512KB 的 `freebsd-boot` 分区。
+
+较老的计算机（如 2013 年以前的）才应该选择选项 `GPT(BIOS)`——此默认选项同时兼容二者。
 
 ![](../.gitbook/assets/ins8.2.png)
 
@@ -131,7 +133,7 @@ FreeBSD 14.2 RELEASE 的 `/` 分区支持 UFS 和 ZFS 两种文件系统。旧�
 
 如果在安装 FreeBSD 的时候选择了 ZFS 磁盘加密，那么如何挂载该磁盘呢？
 
-NVMe 硬盘 ZFS 加密后的磁盘结构：
+NVMe 硬盘 ZFS 加密后的磁盘结构（同时加密了交换空间）：
 
 |     分区类型      | 挂载点 |             设备              |
 | :---------------: | :----: | :---------------------------: |
@@ -139,14 +141,15 @@ NVMe 硬盘 ZFS 加密后的磁盘结构：
 |    freebsd-zfs    |   /    | /dev/nda0p2/、/dev/nda0p2.eli |
 |   freebsd-swap    |        | /dev/nda0p3、/dev/nda0p3.eli  |
 
+浏览 EFI 分区会发现并无特殊之处，同正常安装一样。启动时会提示输入密码以挂载根分区。
 
-很简单，也不需要密钥。执行命令
+如果是在 LiveCD 挂载，也很简单，也不需要密钥。执行命令：
 
 ```sh
 # geli attach /dev/nda0p3
 ```
 
-然后输入正确的密码即可通过命令 `# zfs mount zroot/ROOT/default` 导入磁盘。
+然后输入正确的密码即可通过命令 `# zfs mount zroot/ROOT/default` 导入磁盘即可。
 
 ## Auto (UFS)（使用 UFS 作为 `/` 文件系统）
 


### PR DESCRIPTION
## Sourcery 总结

改进 FreeBSD 安装指南，添加 GPT 分区选择中缺失的详细信息，并增强关于挂载带有交换加密的 ZFS 加密 NVMe 磁盘的说明。

改进点：
- 澄清分区方案建议，建议现代系统使用 GPT+UEFI，并警告不要选择默认的 GPT(BIOS)，因为存在 4K 对齐问题和额外的 freebsd-boot 分区。
- 扩展 ZFS 加密部分，指出交换分区也已加密，且 EFI 分区不受影响。
- 澄清 LiveCD 挂载加密 ZFS 卷的步骤，明确指定 `geli attach` 和 `zfs mount` 命令。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

增强 FreeBSD 安装文档，提供更清晰的 GPT 分区指南和 ZFS 加密说明，并更新 Auto-Assign GitHub Actions 工作流，增加 checkout 步骤和自定义配置。

改进点：
- 阐明 GPT+UEFI 推荐，并警告不要使用默认的 GPT(BIOS)，因为 4K 对齐问题和额外的 freebsd-boot 分区
- 扩展 ZFS 加密部分，以说明 swap 也被加密，且 EFI 分区不受影响
- 详细说明 LiveCD 挂载步骤，附带明确的 geli attach 和 zfs mount 命令

CI：
- 为 Auto-Assign 工作流添加 actions/checkout@v5 步骤和自定义的 repo-token 配置
- 配置 kentaro-m/auto-assign-action，使用固定的指派人、审阅者设置和跳过关键字

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance FreeBSD installation documentation with clearer GPT partition guidance and ZFS encryption instructions, and update the Auto-Assign GitHub Actions workflow with a checkout step and custom configuration.

Enhancements:
- Clarify GPT+UEFI recommendation and warn against default GPT(BIOS) due to 4K alignment and extra freebsd-boot partition
- Expand ZFS encryption section to note that swap is also encrypted and EFI partition remains unaffected
- Detail LiveCD mounting steps with explicit geli attach and zfs mount commands

CI:
- Add actions/checkout@v5 step and custom repo-token configuration to Auto-Assign workflow
- Configure kentaro-m/auto-assign-action with fixed assignee, reviewer settings, and skip keywords

</details>

</details>