### PR TITLE
补充注意

### DIFF
--- a/.github/workflows/Auto-Assign.yml
+++ b/.github/workflows/Auto-Assign.yml
@@ -27,4 +27,4 @@ jobs:
         uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: '.github/some_name_for_configs.yml'
+          configuration-path: '.github/auto_assign.yml'

--- a/di-21-zhang-linux-jian-rong-ceng/di-21.3-jie-linux-jian-rong-ceng-ji-yu-ubuntudebian.md
+++ b/di-21-zhang-linux-jian-rong-ceng/di-21.3-jie-linux-jian-rong-ceng-ji-yu-ubuntudebian.md
@@ -1,5 +1,9 @@
 # 21.3 Ubuntu/Debian 兼容层
 
+>**注意**
+>
+>由于 Port [sysutils/debootstrap](https://www.freshports.org/sysutils/debootstrap/) 长期未更新，经测试尚不支持 Ubuntu 24.04 和 Debian 13。
+
 视频教程：[06-FreeBSD-Ubuntu 兼容层脚本使用说明](https://www.bilibili.com/video/BV1iM4y1j7E9)
 
 ## Ubuntu 兼容层


### PR DESCRIPTION
## Sourcery 总结

文档：
- 添加警告，说明 sysutils/debootstrap 已过时，且与 Ubuntu 24.04 和 Debian 13 不兼容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add warning that sysutils/debootstrap is outdated and not compatible with Ubuntu 24.04 and Debian 13.

</details>