### PR TITLE
Missing CN regulatory domain and 11ac/DFS support in regdomain.xml

### DIFF
--- a/di-14-zhang-wang-luo-guan-li/di-14.2-jie-wifi.md
+++ b/di-14-zhang-wang-luo-guan-li/di-14.2-jie-wifi.md
@@ -74,7 +74,7 @@ test_5G                           50:d6:c5:93:d7:64   36   54M  -78:-95   100 EP
 ```sh
 # ifconfig wlan0 destroy # 先销毁，否则提示 ifconfig: SIOCS80211: Device busy
 # ifconfig wlan0 create wlandev rtwn0 # 再创建
-# ifconfig wlan0 country CN regdomain NONE # 设置区域为中国，使用 NONE
+# ifconfig wlan0 country HR regdomain ETSI # 如果信道 >48（DFS），需要这么设置。如信道小于 48，可以不设置。
 ```
 
 - 重启网络服务以接入 WiFi：
@@ -109,7 +109,7 @@ psk="freebsdcn"
 ```sh
 wlans_rtwn0="wlan0"
 ifconfig_wlan0="WPA SYNCDHCP"
-create_args_wlan0="country CN regdomain NONE"
+create_args_wlan0="country HR regdomain ETSI" # 如果信道 >48（DFS），需要这么设置。如信道小于 48，可以不设置。
 ```
 
 - 重启系统
@@ -147,7 +147,6 @@ iwlwifi 驱动[适用于](https://wiki.freebsd.org/WiFi/Iwlwifi/Chipsets)`AC 826
 - 将以下部分写入 `/etc/rc.conf`：
 
 ```sh
-devmatch_blocklist="iwm"  # 如果依然加载 iwm，换成 devmatch_blocklist="if_iwm" 试一下
 wlans_iwlwifi0="wlan0"
 ifconfig_wlan0="WPA SYNCDHCP"
 ```
@@ -161,17 +160,11 @@ psk="WIFI 密码"
 }
 ```
 
-- 先加载驱动看一下：
-
-```sh
-# kldload if_iwlwifi
-```
-
 - 启动 WiFi 看看：
 
 ```sh
 # ifconfig wlan0 create wlandev iwlwifi0
-# /etc/rc.d/netif start  wlan0
+# /etc/rc.d/netif start wlan0
 ```
 
 故障排除与未竟事宜：[wiki/WiFi/Iwlwifi](https://wiki.freebsd.org/WiFi/Iwlwifi)

--- a/di-2-zhang-an-zhuang-freebsd/di-2.7-jie-net.md
+++ b/di-2-zhang-an-zhuang-freebsd/di-2.7-jie-net.md
@@ -34,6 +34,10 @@
 
 ## 无线网卡/ WiFi 设置
 
+>**警告**
+>
+>由于 [Missing CN regulatory domain and 11ac/DFS support in regdomain.xml ](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289202)，故此部分存在问题，请跳过。
+
 >**注意**
 >
 >建议跳过此部分，重启进入系统后再参照无线网络相关内容进行设置（尤其是博通网卡用户）。否则可能会无限卡住或直接 Panic。


### PR DESCRIPTION
## Sourcery 摘要

文档：
- 添加一个警告，提及 FreeBSD bug 289202，该 bug 是关于 regdomain.xml 中缺少中国 (CN) 监管域以及 11ac/DFS 支持的问题，并建议用户跳过无线设置部分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a warning referencing FreeBSD bug 289202 about missing CN regulatory domain and 11ac/DFS support in regdomain.xml and advise users to skip the wireless setup section.

</details>