### PR TITLE
typo

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.16-kde-wayland.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.16-kde-wayland.md
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-由于 issue [Request to restore support for vboxvideo and vmwgfx DRM drivers #356](https://github.com/freebsd/drm-kmod/issues/356) 始终未能得到解决，故在 VMware、VirtualBox 或任何基于 Virtio 的虚拟机上均无法复现此教程。你需要在真实的物理机上进行参照。
+由于 issue [Request to restore support for vboxvideo and vmwgfx DRM drivers #356](https://github.com/freebsd/drm-kmod/issues/356) 始终未能得到解决（FreeBSD drm 驱动的移植只覆盖了 Intel、AMD 和 NVIDIA 等 GPU），故在 VMware、VirtualBox 或任何基于 Virtio 的虚拟机上均无法复现此教程。你需要在真实的物理机上进行参照。
 
 NVIDIA 卡未经测试。本文使用 Intel 12 代处理器（i7-1260P）的核显进行测试。
 

--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.16-kde-wayland.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.16-kde-wayland.md
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-由于 issue [Request to restore support for vboxvideo and vmwgfx DRM drivers #356](https://github.com/freebsd/drm-kmod/issues/356) 一直未得到解决，故在任何 VMware、Virtual Box 或基于 Virtio 的虚拟机上均无法复现此教程。你需要在真实的物理机上进行参照。
+由于 issue [Request to restore support for vboxvideo and vmwgfx DRM drivers #356](https://github.com/freebsd/drm-kmod/issues/356) 一直未得到解决，故在 VMware、VirtualBox 或任何基于 Virtio 的虚拟机上均无法复现此教程。你需要在真实的物理机上进行参照。
 
 NVIDIA 卡未经测试。本文使用 Intel 12 代处理器（i7-1260P）的核显进行测试。
 

--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.16-kde-wayland.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.16-kde-wayland.md
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-由于 issue [Request to restore support for vboxvideo and vmwgfx DRM drivers #356](https://github.com/freebsd/drm-kmod/issues/356) 一直未得到解决，故在 VMware、VirtualBox 或任何基于 Virtio 的虚拟机上均无法复现此教程。你需要在真实的物理机上进行参照。
+由于 issue [Request to restore support for vboxvideo and vmwgfx DRM drivers #356](https://github.com/freebsd/drm-kmod/issues/356) 始终未能得到解决，故在 VMware、VirtualBox 或任何基于 Virtio 的虚拟机上均无法复现此教程。你需要在真实的物理机上进行参照。
 
 NVIDIA 卡未经测试。本文使用 Intel 12 代处理器（i7-1260P）的核显进行测试。
 


### PR DESCRIPTION
## Sourcery 总结

文档:
- 将 'Virtual Box' 更正为 'VirtualBox' 并重新排序 di-6.16-kde-wayland.md 中的 VM 示例

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

文档：
- 修复 'Virtual Box' 拼写错误为 'VirtualBox'，并重新排序设置指南中的虚拟机示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix 'Virtual Box' typo to 'VirtualBox' and reorder the VM examples in the setup guide.

</details>

</details>