### PR TITLE
FreeBSD 内核拥有五种不同的安全级别

### DIFF
--- a/di-1-zhang-zou-jin-freebsd/di-1.2-dao-lun.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.2-dao-lun.md
@@ -133,13 +133,15 @@ FreeBSD 不仅仅是 **在生命周期内不变**，大版本更新也具有连�
 - 安全事件审计。
 - 集成了标准 Unix DAC、ACL、TrustedBSD MAC 安全框架（基于 POSIX®.1e 草案的安全扩展），参见 [wiki TrustedBSD](https://wiki.freebsd.org/TrustedBSD/)
 - 集成 W^X 策略，参见 [Implement enforcing write XOR execute mapping policy.](https://reviews.freebsd.org/D28050)
-- 默认启用了内核和用户空间的 ASLR，参见 [Enable ASLR by default for 64-bit executables.](https://reviews.freebsd.org/D27666)
+- 默认启用了内核和用户空间的 PIE 和 ASLR，参见 [Enable ASLR by default for 64-bit executables.](https://reviews.freebsd.org/D27666)
 - FreeBSD 通过了 National Institutes of Standards and Technology（NIST，美国国家标准及技术研究所）安全软件开发框架（SSDF）认证，参见 [FreeBSD Foundation Announces SSDF Attestation](https://freebsdfoundation.org/news-and-events/latest-news/freebsd-foundation-announces-ssdf-attestation/)
 - 实现了 FreeBSD 14 CIS 基准。参见 [New CIS® FreeBSD 14 Benchmark: Secure Your Systems with Expert-Guided Best Practices](https://freebsdfoundation.org/blog/new-cis-freebsd-14-benchmark-secure-your-systems-with-expert-guided-best-practices/)
 - 正在实现 FreeBSD 的零信任构建，参见 Sovereign Tech Agency 相关赞助
 - 基于 GEOM 框架的全盘加密（含 ZFS、Swap）方案
 - 正在改进软件物料清单（Software Bill of Materials，SBOM），参见 Sovereign Tech Agency 相关赞助
 - Capsicum 框架，并且已经对基本系统中大量工具进行了能力化加固。参见 [wiki Capsicum](https://wiki.freebsd.org/Capsicum)
+- FreeBSD 内核拥有五种不同的安全级别（securelevel）可以自由选择，参见 [man mitigations](https://man.freebsd.org/cgi/man.cgi?query=mitigations)，还介绍了 FreeBSD 上若干安全漏洞缓解手段
+  
   
 #### 参考文献
 


### PR DESCRIPTION
## Sourcery 摘要

更新安全功能列表以包含 PIE 支持并记录内核安全级别

增强功能：
- 默认情况下为 64 位内核和用户空间可执行文件启用 PIE 和 ASLR
- 添加一个新的要点，描述 FreeBSD 的五个内核安全级别以及相关的缓解措施

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the security features list to include PIE support and document kernel secure levels

Enhancements:
- Enable PIE alongside ASLR by default for 64-bit kernel and user-space executables
- Add a new bullet describing FreeBSD's five kernel secure levels and related mitigation measures

</details>