### PR TITLE
root 下没声音

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.16-kde-wayland.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.16-kde-wayland.md
@@ -142,6 +142,10 @@ $ sh ~/kde.sh
 
 待解决。
 
+### root 下没声音
+
+表现为右下角声音选项卡提示“未连接到音频服务”：设置 PulseAudio 自启即可，可在 KDE 设置中自行添加，注意加入可执行权限。
+
 ## 参考文献
 
 - [KDE Plasma 6 Wayland on FreeBSD](https://euroquis.nl/kde/2025/09/07/wayland.html)，此处提示需要 `seatd`。


### PR DESCRIPTION
## Sourcery 总结

文档：
- 添加一个“root 下没声音”的故障排除部分，建议在 KDE 设置中进行 PulseAudio 自动启动设置并赋予可执行权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a "root 下没声音" troubleshooting section suggesting PulseAudio auto-start setup in KDE settings with executable permission.

</details>