### PR TITLE
adduser(8)

### DIFF
--- a/di-2-zhang-an-zhuang-freebsd/di-2.8-jie-more.md
+++ b/di-2-zhang-an-zhuang-freebsd/di-2.8-jie-more.md
@@ -143,7 +143,7 @@ Home directory [/home/ykla]: # 用户主（家）目录，普通用户默认在 
 Home directory permissions (Leave empty for default): # 用户主（家）目录权限，留空将使用默认值
 Use password-based authentication? [yes]:  # 是否启用密码验证
 Use an empty password? (yes/no) [no]:  # 是否使用空密码，即密码为空
-Use a random password? (yes/no) [no]:  # 是否使用随机密码。若设置 yes 将生成随机字符串用作密码。该密码会回显到标准输出。
+Use a random password? (yes/no) [no]:  # 是否使用随机密码。若设置 yes 将生成随机字符串用作密码。该密码会回显到标准输出。②
 Enter password:  # 输入密码，密码不显示在屏幕上，也不会是 ****，就是什么也没有
 Enter password again:  # 重复输入密码，密码不显示在屏幕上，也不会是 ****，就是什么也没有
 Lock out the account after creation? [no]: # 创建账户后锁定账户（禁用该账户）
@@ -164,6 +164,8 @@ Add another user? (yes/no) [no]: # 是否还要再添加其他用户
 ```
 
 - ① 如果用户全名为空（即不设置），系统会分配一个默认值 `User &`。这是早期 Unix 的行为（Gecos 字段）。由 [freebsd-src/blob/main/usr.sbin/pw/pw_user.c](https://github.com/freebsd/freebsd-src/blob/main/usr.sbin/pw/pw_user.c)，文件中的 `static struct passwd fakeuser` 这部分代码实现。
+
+- ② 如果设置使用随机密码，在最后的部分会输出：`adduser: INFO: Password for (ykla) is: D1MnujkWMv/m`（adduser：信息：用户 (ykla) 的密码是：D1MnujkWMv/m）。
 
 其他参数可以保持默认设置不变。在 FreeBSD 14 及以后，所有用户的默认 shell 都被统一为了 `sh`。
 


### PR DESCRIPTION
## Sourcery 总结

通过指定输入限制、默认行为，并添加手册页引用，澄清 FreeBSD 安装程序中的交互式 adduser 提示。

文档：
- 指定用户名限制，包括字符集、长度和格式规则
- 澄清全名为可选且不能包含冒号
- 注意手动设置的 UID 必须小于 32000，并说明空输入的默认行为
- 更新主目录权限提示，以反映留空时的默认用法
- 澄清空密码和随机密码选项的行为，包括随机选择时显示密码
- 解释锁定账户将禁用用户
- 添加一个链接到 adduser(8) 手册页的参考部分

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the interactive adduser prompts in the FreeBSD installer by specifying input constraints, default behaviors, and adding a reference to the manual page.

Documentation:
- Specify username constraints including character set, length, and formatting rules
- Clarify that full name is optional and cannot contain colons
- Note that manually set UIDs must be less than 32000 and default behavior for empty input
- Update home directory permission prompt to reflect default usage when left empty
- Clarify behavior of empty and random password options, including password reveal for random choice
- Explain that locking the account will disable the user
- Add a reference section linking to the adduser(8) man page

</details>