### PR TITLE
zfs 向前扩展

### DIFF
--- a/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.3-jie-ci-pan-kuo-rong.md
+++ b/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.3-jie-ci-pan-kuo-rong.md
@@ -6,6 +6,9 @@
 
 ## ZFS 磁盘扩容
 
+>**注意**
+>
+>此方案仅适用于向后扩展，如果 freebsd-zfs 分区前面有空余空间则无法使用此方法扩展。
 
 ```sh
 root@ykla:~ # gpart show
@@ -83,7 +86,9 @@ zroot  77.5G  2.20G  75.3G        -         -     2%     2%  1.00x    ONLINE  -
 
 ## UFS 磁盘扩容
 
-
+>**注意**
+>
+>此方案仅适用于向后扩展，如果 freebsd-ufs 分区前面有空余空间则无法使用此方法扩展。
 
 - `gpart show` 查看磁盘分区
 
@@ -210,3 +215,29 @@ UFS 全称是 Unix File System，即 UNIX 文件系统，基于 UNIX v7。过去
 > **注意**
 >
 > UFS 文件系统和手机等设备中使用的 UFS 存储完全不是一回事，那个 UFS 是 Universal Flash Storage（通用闪存存储）的缩写，已经出到 4.0 了（FreeBSD 于 10.4 支持 eMMC；而 UFS 出现在 FreeBSD 15.0 的开发计划中，尚不支持）。而作为文件系统的 UFS 版本号才是 2。而且手机内部的系统也不可能是 UFS 文件系统，因为基于 Linux 的安卓根本不支持 UFS 这个文件系统，这些设备一般的根文件系统是 ext4（一些新设备是 F2FS）。
+
+## 故障排除
+
+### zfs 向前扩展
+
+**错误方法**
+
+>**警告**
+>
+>这是错误方法，请勿在生产环境尝试。
+
+如果使用 zfs 作为 /：
+
+```sh
+# gpart add -t freebsd-zfs -a 4k -s 210751598 -l add100G diskid/DISK-FXS690MQ233011234
+# zpool add root /dev/gpt/add100G
+```
+
+重启后会发现，启动加载器会报错 ` ZFS: i/o error - all block copies unavailable`。
+
+待探索其他方案。
+
+#### 参考文献
+
+- [FreeBSD root on ZFS 千古奇坑](https://dieken.gitlab.io/posts/bsd-as-desktop-system/)，不知道有无关联，但是报错是相同的
+- [10.1 doesn't boot anymore from zroot after applying p25](https://forums.freebsd.org/threads/10-1-doesnt-boot-anymore-from-zroot-after-applying-p25.54422/#post-308876)，论坛的反馈


### PR DESCRIPTION
## Sourcery 总结

更新磁盘扩容流程文档，阐明其适用性，并添加 ZFS 向前扩展的故障排除部分。

文档内容：
- 添加注意事项，指出 ZFS 和 UFS 扩展方法仅支持扩展到分区后的可用空间。
- 引入 ZFS 向前扩展的故障排除部分，其中包含错误方法的示例、相关错误以及参考链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation for disk expansion procedures, clarifying applicability and adding a troubleshooting section for ZFS forward extension.

Documentation:
- Add caveat notes that ZFS and UFS expansion methods only support extending into space after the partition.
- Introduce a troubleshooting section for ZFS forward expansion with an example of the incorrect approach, associated error, and reference links.

</details>