### PR TITLE
更新 CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@
 
 ---
 
-在今年 6 月 BSDCan 大会上，原作者之一的 Marshall Kirk McKusick 表示，《The Design and Implementation of the FreeBSD Operating System》（《FreeBSD 操作系统设计与实现》）第三版的编写工作正在筹备中。培生教育将不再负责第三版的发行工作。培生已将著作权归还原作者。已与 No Starch 出版社签约合作，由其负责第三版的出版事宜。该书籍项目正在扩充作者团队：
-•Kirk McKusick：前言、发展历程、FFS 文件系统、项目统筹
-•George Neville-Neil：网络通信
-•Robert Watson：安全机制
-•John Baldwin：内核服务、进程管理、虚拟化
-•Warner Losh：I/O 系统、设备驱动、系统启动
-•Mark Johnson：内存管理
-•Allan Jude：ZFS 文件系统
-•Rick Macklem：网络文件系统
+在今年 6 月 BSDCan 大会上，原作者之一的 Marshall Kirk McKusick 表示，*The Design and Implementation of the FreeBSD Operating System*（《FreeBSD 操作系统设计与实现》）第三版的编写工作正在筹备中。培生教育将不再负责第三版的发行工作。培生已将著作权归还原作者。已与 No Starch 出版社签约合作，由其负责第三版的出版事宜。该书籍项目正在扩充作者团队：
+
+- Kirk McKusick：前言、发展历程、FFS 文件系统、项目统筹
+- George Neville-Neil：网络通信
+- Robert Watson：安全机制
+- John Baldwin：内核服务、进程管理、虚拟化
+- Warner Losh：I/O 系统、设备驱动、系统启动
+- Mark Johnson：内存管理
+- Allan Jude：ZFS 文件系统
+- Rick Macklem：网络文件系统
+
 ---
 
 - 2025.10.6


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 添加 2025.10.8 变更日志条目，详细说明 FreeBSD 书籍第三版的准备工作、出版商过渡以及作者阵容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add 2025.10.8 changelog entry detailing the FreeBSD book third edition preparations, publisher transition, and author lineup.

</details>