### PR TITLE
内核模块源

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.1-jie-an-zhuang-xian-ka-qu-dong-ji-xorg-bi-kan.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.1-jie-an-zhuang-xian-ka-qu-dong-ji-xorg-bi-kan.md
@@ -116,7 +116,7 @@ DRM 即“Direct Rendering Manager”（直接渲染管理器），DRM 是 Linux
 
 - `KLD XXX.ko depends on kernel - not available or version mismatch.`
 
-提示内核版本不符，请先升级系统或使用 ports 编译安装。
+提示内核版本不符，请先升级系统或使用 ports 编译安装。14.3-RELEASE 及以上版本可以用内置的内核模块源（参见其他章节），应该不会出现类似问题。
 
 ![](../.gitbook/assets/amd_error.png)
 


### PR DESCRIPTION
## Sourcery 总结

文档:
- 添加说明，指出 FreeBSD 14.3-RELEASE 及更高版本可以使用内置的内核模块源，以防止内核版本不匹配错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add note that FreeBSD 14.3-RELEASE and above can use built-in kernel module source to prevent kernel version mismatch errors.

</details>