### PR TITLE
typo

### DIFF
--- a/di-24-zhang-dragonflybsd/di-24.2-jie-an-zhuang-yu-pei-zhi.md
+++ b/di-24-zhang-dragonflybsd/di-24.2-jie-an-zhuang-yu-pei-zhi.md
@@ -14,7 +14,7 @@ U 盘安装应使用 `USB: dfly-x86_64-6.4.0_REL.img as bzip2 file`：解压出 
 
 ![](../.gitbook/assets/dragonflybsd1.png)  
 
-输入用户名 `intaller`（即安装的意思）开始安装。
+输入用户名 `installer`（即安装的意思）开始安装。
 
 ![](../.gitbook/assets/dragonflybsd2.png)  
 


### PR DESCRIPTION
## Sourcery 总结

文档：
- 修复安装说明中的拼写错误，将用户名从 "intaller" 改为 "installer"

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix typo in installation instructions by changing username from "intaller" to "installer"

</details>