### PR TITLE
补充警告

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.1-jie-an-zhuang-xian-ka-qu-dong-ji-xorg-bi-kan.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.1-jie-an-zhuang-xian-ka-qu-dong-ji-xorg-bi-kan.md
@@ -17,7 +17,7 @@ FreeBSD 的 i915、AMD 显卡驱动和与基本系统是分离的。目前是移
 
 >**警告**
 >
->这种移植并不覆盖 Linux 现有的全部 drm GPU 驱动，目前仅有 i915 amd 和 radeon，其他 vmwgfx、xe、virtio 都是未进行移植的！
+>这种移植并不覆盖 Linux 现有的全部 drm GPU 驱动，目前仅有 i915 amd 和 radeon，其他 vmwgfx、xe、virtio 等等都是未进行移植的！
 
 
 | **FreeBSD 版本**         | **对应 DRM 驱动版本**                   | **GPU 支持范围（AMD / Intel）**    | **备注**             |


### PR DESCRIPTION
## Sourcery 总结

文档：
- 加入警告以阐明只有 i915、AMD 和 radeon 驱动程序已移植，而 vmwgfx、xe 和 virtio 仍未移植

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

文档：
- 在文档中插入警告块，以说明当前 DRM 驱动移植的有限范围

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Insert warning block in documentation to specify the limited scope of the current DRM driver porting

</details>

</details>