### PR TITLE
补遗

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.1-jie-an-zhuang-xian-ka-qu-dong-ji-xorg-bi-kan.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.1-jie-an-zhuang-xian-ka-qu-dong-ji-xorg-bi-kan.md
@@ -21,7 +21,7 @@ FreeBSD 的 i915、AMD 显卡驱动和与基本系统是分离的。目前是移
 
 >**注意**
 >
->DG2 Arc 显卡尚不受支持（截止 drm 6.10 版本），参见 ［issue](https://github.com/freebsd/drm-kmod/issues/315)。
+>DG2 Arc 显卡尚不受支持（截止 drm 6.10 版本），参见 [Intel Arc A770: Kernel panic on kldload i915kms.ko #315](https://github.com/freebsd/drm-kmod/issues/315)。
 
 | **FreeBSD 版本**         | **对应 DRM 驱动版本**                   | **GPU 支持范围（AMD / Intel）**    | **备注**             |
 | :--------------------------: | :--------------------------------- | :---------------------------- | :------------------- |


### PR DESCRIPTION
## Sourcery 摘要

文档：
- 修改了问题链接文本，以显示完整的“Intel Arc A770: Kernel panic on kldload i915kms.ko #315”标题，而不是一个通用标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Amended the issue link text to display the full ‘Intel Arc A770: Kernel panic on kldload i915kms.ko #315’ title instead of a generic label.

</details>