### PR TITLE
移除不存在的内容

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.1-jie-an-zhuang-xian-ka-qu-dong-ji-xorg-bi-kan.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.1-jie-an-zhuang-xian-ka-qu-dong-ji-xorg-bi-kan.md
@@ -32,12 +32,8 @@ FreeBSD 的 i915、AMD 显卡驱动和与基本系统是分离的。目前是移
 | **FreeBSD 15.0/16.0-CURRENT**                                        | **drm-66-kmod（基于 Linux 6.6 DRM）** | - **AMD：** 自 **GCN 1** 起至 **RDNA 3（Radeon RX 7000 系列）**，并包含 **Instinct MI300 加速卡** 支持。<br>- **Intel：** <br> • **Gen 4–8：** 旧核显（GMA、HD Graphics 4000 等）<br> • **Gen 9：** Skylake / Kaby Lake / Coffee Lake<br> • **Gen 10：** Cannon Lake （已废弃）<br> • **Gen 11：** Ice Lake / Jasper Lake<br> • **Gen 12：** Tiger Lake / Alder Lake <br> • **Gen 13：** Raptor Lake （基本兼容 Alder Lake 驱动）<br> • **Gen 14：** Meteor Lake （实验性，已合入 drm-66） | 实测 **Intel Alder Lake-N (N100)、i7-i260p** 显卡驱动加载正常，显示与视频加速功能稳定；<br><br>理论支持 **Intel 3 ～ 14 代 GPU**（含 Meteor Lake），但 13 代及以后缺乏充分实测；       |
 
 - 非 LTS 版本（Port graphics/drm-latest-kmod/，仅 15.0/16.0，目前 6.9）：
-  - Intel：Meteor Lake 图形在 6.7 后默认启用；6.9 包含实验性 Xe 驱动 ，用于 Gen 12+ GPU （Arc、Meteor Lake 等），为后续 Xe2 / Lunar Lake 做准备。i915 仍为默认。
+  - Intel：Meteor Lake 图形在 6.7 后默认启用；
   - AMD：引入对 **RDNA 3+ / RDNA 4** 的初步支持 。覆盖 GCN 到 RDNA 3 全部架构，并预置 RDNA 4 驱动。
-
-- 后续目标版本（待移植）：6.12（LTS）：
-  - Intel：Xe 驱动成熟，新增 Xe2 (Lunar Lake 核显) 与 Battlemage 独显支持 。加入 Arrow Lake (15 代) 代码。Meteor Lake 完全支持。i915 仍默认，Xe 面向 Gen12+ 新平台。
-  - AMD：RDNA 4 官方支持 ，面向 RX 8000 系列。延续 GCN 至 RDNA 3 所有架构。
 
 >**技巧**
 >


### PR DESCRIPTION
## Sourcery 总结

移除非LTS和未来LTS移植部分中过时和不存在的驱动路线图条目。

增强功能：
- 精简非LTS drm-latest-kmod 部分，仅提及 Meteor Lake 默认启用和初步的 RDNA3/4 支持
- 移除针对版本 6.9 的实验性 Xe 驱动提及
- 删除详细说明 Intel Xe2 和 AMD RDNA4 支持的未来 6.12 (LTS) 移植路线图

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove outdated and non-existent driver roadmap entries from the non-LTS and future LTS port sections.

Enhancements:
- Streamline the non-LTS drm-latest-kmod section to only mention Meteor Lake default enable and preliminary RDNA3/4 support
- Remove the experimental Xe driver mention for version 6.9
- Delete the future 6.12 (LTS) port roadmap detailing Intel Xe2 and AMD RDNA4 support

</details>