### PR TITLE
DG2 Arc not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - 2025.10.11
   - “6.1 Intel 和 AMD 显卡驱动”：明确目前 AMD 显卡驱动存在故障，预计在 15.0 RELEASE 发布前修复；
-  - “6.1 Intel 和 AMD 显卡驱动”：明确目前 FreeBSD 移植的 drm 尚不支持 Intel DG2 Arc 显卡（如 Arc 770），预计在 15.1 RELEASE 前得到支持。
+  - “6.1 Intel 和 AMD 显卡驱动”：明确目前 FreeBSD 移植的 drm 尚不支持 Intel DG2 Arc 显卡（如 Arc A770），预计在 15.1 RELEASE 前得到支持。
 - 2025.10.10
   - “6.1 Intel 和 AMD 显卡驱动”重写“显卡支持情况”
   - 提交 [Bug 290122 - graphics/drm-latest-kmod：and related DRM ports missing CONFLICTS_INSTALL entries](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=290122)


### PR DESCRIPTION
## Sourcery 总结

更新变更日志，以阐明当前的 GPU 驱动支持状态和预期时间表

文档：
- 添加说明，指出 AMD 显卡驱动存在一个已知问题，将在 15.0 版本发布前修复
- 添加说明，指出 Intel DG2 Arc GPU（例如 Arc 770）尚未被 FreeBSD DRM 端口支持，并将在 15.1 版本发布前获得支持

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

文档:
- 澄清 AMD GPU 驱动程序存在一个已知问题，该问题将在 15.0 版本发布前修复，并且 Intel DG2 Arc GPU 将在 15.1 版本中支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify that the AMD GPU driver has a known issue to be fixed before the 15.0 release and that Intel DG2 Arc GPUs will be supported in the 15.1 release.

</details>

</details>