### PR TITLE
fix #1288

### DIFF
--- a/fu-lu2/yi-tai-wang-ka.md
+++ b/fu-lu2/yi-tai-wang-ka.md
@@ -36,6 +36,12 @@
 
 #### 安装方法
 
+* 使用 pkg 安装：
+  
+```
+pkg install realtek-re-kmod
+```
+
 * 使用 Ports 安装：
 
 ```sh
@@ -47,11 +53,10 @@
 >
 >编译安装时，需要有一份源代码在 `/usr/src`。
 
-* 使用 pkg 安装：
-  
-```
-pkg install realtek-re-kmod
-```
+
+>**技巧**
+>
+>如果你的 realtek 网卡仍存在断流，时有时无等情况，可以试试 [net/realtek-re-kmod198](https://www.freshports.org/net/realtek-re-kmod198/)，参见 [Bug 275882 - net/realtek-re-kmod: Problem with checksum offload since +199.00](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=275882)。
 
 ---
 


### PR DESCRIPTION
## Sourcery 总结

重构 realtek-re-kmod 的安装指南，并添加有关网络不稳定性的故障排除说明。

文档：
- 将 `pkg install realtek-re-kmod` 说明移至 安装方法 下，并删除重复的部分
- 添加一个故障排除提示，链接到 net/realtek-re-kmod198 端口和 Bug 275882，以解决间歇性网络问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restructure the installation guide for realtek-re-kmod and add a troubleshooting note for network instability

Documentation:
- Move `pkg install realtek-re-kmod` instructions under 安装方法 and remove duplicate section
- Add a troubleshooting tip linking to net/realtek-re-kmod198 port and Bug 275882 for intermittent network issues

</details>