### PR TITLE
补充警告

### DIFF
--- a/di-1-zhang-zou-jin-freebsd/di-1.2-dao-lun.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.2-dao-lun.md
@@ -216,6 +216,9 @@ current 相对稳定后（即 MFC 最短三天，MFC 即 `Merge From Head`，类
 
 ![FreeBSD 版本更迭](../.gitbook/assets/bsd-release.png)
 
+>**警告**
+>
+>上图并不严谨，X.0-RELEASE 其实来自 X-STABLE；X-STABLE 直接由 X-1.CURRENT 转化而来。暂无力修改。待定。
 
 >**注意**
 >


### PR DESCRIPTION
## Sourcery 总结

文档：
- 在 FreeBSD 版本演进图下方添加一个警告说明，指出 X.0-RELEASE 实际上源自 X-STABLE，而 X-STABLE 又来自 X-1.CURRENT。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a warning note under the FreeBSD version evolution diagram to indicate that X.0-RELEASE actually stems from X-STABLE, which in turn comes from X-1.CURRENT.

</details>