### PR TITLE
补遗

### DIFF
--- a/.github/workflows/Auto-Assign.yml
+++ b/.github/workflows/Auto-Assign.yml
@@ -5,13 +5,12 @@ on:
     types: [opened, reopened]
   pull_request:
     types: [opened, ready_for_review, reopened, synchronize]
-  repository_dispatch:
   workflow_dispatch:
 
 jobs:
   assign-issue:
     runs-on: ubuntu-latest
-    if: github.event_name == 'issues'
+    if: github.event_name == 'issues' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: pozil/auto-assign-issue@v2.2.0
         with:
@@ -21,7 +20,7 @@ jobs:
 
   assign-pr:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Auto Assign PR
         uses: kentaro-m/auto-assign-action@v2.0.0


### PR DESCRIPTION
## Sourcery 总结

为自动分配工作流启用手动工作流调度，并清理未使用的调度触发器

CI:
- 从自动分配工作流中移除 repository_dispatch 触发器
- 扩展问题和 PR 自动分配作业，使其除了原始触发器外，还能在 workflow_dispatch 事件上运行

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable manual workflow dispatch for the auto-assign workflow and clean up unused dispatch trigger

CI:
- Remove repository_dispatch trigger from Auto-Assign workflow
- Extend issue and PR auto-assign jobs to run on workflow_dispatch events in addition to their original triggers

</details>