### PR TITLE
typo

### DIFF
--- a/di-5-zhang-bao-guan-li-qi/di-5.5-jie-tong-guo-yuan-dai-ma-ports-fang-shi-an-zhuang-ruan-jian.md
+++ b/di-5-zhang-bao-guan-li-qi/di-5.5-jie-tong-guo-yuan-dai-ma-ports-fang-shi-an-zhuang-ruan-jian.md
@@ -20,7 +20,7 @@ chinese		french		lang		polish		UIDs		x11-wm
 comms		ftp		mail		ports-mgmt	ukrainian
 CONTRIBUTING.md	games		Makefile	portuguese	UPDATING
 converters	german		math		print		vietnamese
-ykla@ykla:/usr/ports $ ls databases/ # ② 切换到 databases 数据库分类目录下
+ykla@ykla:/usr/ports $ ls databases/ # 切换到 databases 数据库分类目录下
 adminer						php-xapian
 adodb5						php81-dba
 


### PR DESCRIPTION
## Sourcery 总结

文档：
- 移除 `di-5.5-jie-tong-guo-yuan-dai-ma-ports-fang-shi-an-zhuang-ruan-jian.md` 文件中中文注释里多余的“②”。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Remove extraneous “②” from the Chinese comment in di-5.5-jie-tong-guo-yuan-dai-ma-ports-fang-shi-an-zhuang-ruan-jian.md

</details>