### PR TITLE
增补混用 pkg 镜像站的警告

### DIFF
--- a/di-5-zhang-bao-guan-li-qi/di-5.2-jie-freebsd-huan-yuan-fang-shi.md
+++ b/di-5-zhang-bao-guan-li-qi/di-5.2-jie-freebsd-huan-yuan-fang-shi.md
@@ -36,7 +36,7 @@ FreeBSD 中 pkg 源分为系统级和用户级两个配置文件。**不建议**
 
 >**警告**
 >
-> 请勿同时启用多个 pkg 镜像站，无论是官方镜像站（如 `pkg.freebsd.org` 与 USTC 混用），还是境内非官方镜像站（如 USTC 和 NJU 混用）都不要混合使用！案例：[混用导致 KDE 桌面被删除](https://blog.mxdyeah.top/mxdyeah_blog_post/freebsd_exp_kde6.html)。
+> 请勿同时启用多个 pkg 镜像站，无论是官方镜像站（如 `pkg.freebsd.org` 与 USTC 混用），还是境内非官方镜像站（如 USTC 和 NJU 混用）都不要混合使用！后果类似于 FreeBSD 季度分支的 Ports 和 latest 分支的 pkg 混用，可能会破坏软件的依赖关系。案例：[混用导致 KDE 桌面被删除](https://blog.mxdyeah.top/mxdyeah_blog_post/freebsd_exp_kde6.html)。
 
 ### 理解 quarterly 季度分支
 


### PR DESCRIPTION
## Sourcery 总结

文档：
- 添加一个“警告”块，警告不要混合官方和非官方的 pkg 镜像，并附带一个 KDE 删除的例子。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a “警告” block cautioned against mixing official and non-official pkg mirrors, with an example of KDE deletion.

</details>