### PR TITLE
Fix Budgie login issue description and add link

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.10-jie-an-zhuang-budgie.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.10-jie-an-zhuang-budgie.md
@@ -1,6 +1,6 @@
 # 6.10 Budgie（预备删除）
 
->目前 Budgie 但无法正常登录桌面。Bug 289898 x11/budgie: After logging in with LightDM, it crashes and then shows a black screen.。若在六个月内（2025-04-01 日前）未得到解决将删除“6.10 Budgie”。
+>目前 Budgie 但无法正常登录桌面。[Bug 289898 x11/budgie: After logging in with LightDM, it crashes and then shows a black screen](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289898)。若在六个月内（2025-04-01 日前）未得到解决将删除“6.10 Budgie”。
 
 Budgie 是 [Solus Linux](https://getsol.us/) 的默认桌面。
 


### PR DESCRIPTION
Updated the bug reference for Budgie login issue with a link.

## Sourcery 总结

文档:
- 在 Budgie 登录问题描述中添加 Bug 289898 的超链接

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add hyperlink to Bug 289898 in the Budgie login issue description

</details>