### PR TITLE
测试 cleanUrls

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -137,6 +137,7 @@ export default defineConfig({
 	title: "FreeBSD 从入门到跑路",
 	description: "FreeBSD 从入门到跑路",
 	metaChunk: true,
+cleanUrls:true, // 在 URL 中去掉 .html 后缀
 markdown: {
   image: { lazyLoading: true },
   config: (md) => {


### PR DESCRIPTION
## Sourcery 总结

改进：
- 在 VitePress 配置中启用 cleanUrls 以从 URL 中移除 .html 后缀

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Enable cleanUrls in VitePress config to remove .html suffix from URLs

</details>