### PR TITLE
typo

### DIFF
--- a/di-4-zhang-freebsd-base/di-4.1-windows.md
+++ b/di-4-zhang-freebsd-base/di-4.1-windows.md
@@ -165,4 +165,4 @@ Windows 会即直接读取 RTC 的结果，把其当成默认的本地时间，�
 
 - [秒的定义](https://www.nim.ac.cn/520/node/4.html)，中国计量科学院载秒的定义
 - [Time Zone Database](https://www.iana.org/time-zones)，时区数据库
-- ［历书基本术语简介](http://www.pmo.cas.cn/xwdt2019/kpdt2019/202203/t20220314_6389637.html#b4)，本文所涉术语，可参考此处中国科学院紫金山天文台的精确解释
+- [历书基本术语简介](http://www.pmo.cas.cn/xwdt2019/kpdt2019/202203/t20220314_6389637.html#b4)，本文所涉术语，可参考此处中国科学院紫金山天文台的精确解释


### PR DESCRIPTION
## Sourcery 总结

文档:
- 修正 '历书基本术语简介' 链接中的括号样式，使其使用标准 ASCII 括号

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the bracket style in the '历书基本术语简介' link to use standard ASCII brackets

</details>