### PR TITLE
更替字体

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -92,11 +92,12 @@
 /* 引入霞鹜文楷字体 */
 
 
-@import url('https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/style.min.css');
+@import url('https://cdn.jsdelivr.net/npm/lxgw-wenkai-gb-web@latest/style.css');
+@import url('https://cdn.jsdelivr.net/npm/lxgwwenkaimonogb-regular@latest/style.css');
 
 :root {
-        --vp-font-family-base: 'LXGW WenKai Screen', 'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
+        --vp-font-family-base: 'LXGW Wenkai GB', 'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
                 'Droid Sans', 'Helvetica Neue', sans-serif;
-        --vp-font-family-mono: 'LXGW WenKai Screen', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        --vp-font-family-mono: 'LXGW WenKai Mono GB', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 } 
 


### PR DESCRIPTION
## Sourcery 总结

将文楷字体替换为 GB 和 Mono GB 变体，并将导入更新到最新版本

增强功能：
- 导入 LXGW 文楷 GB 和 Mono GB 网络字体，而不是旧的 WenKai Screen 包
- 更新基础和等宽 CSS 变量以引用新的 GB 字体家族

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace WenKai font with the GB and Mono GB variants and update imports to the latest versions

Enhancements:
- Import LXGW Wenkai GB and Mono GB webfonts instead of the older WenKai Screen package
- Update base and monospace CSS variables to reference the new GB font families

</details>