### PR TITLE
typo

### DIFF
--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -3,7 +3,7 @@
 import DefaultTheme from 'vitepress/theme';
 import './custom.css';
 import Layout from './Layout.vue';
-import 'lxgw-wenkai-gb-web/style.css;
+import 'lxgw-wenkai-gb-web/style.css';
 
 
 export default {


### PR DESCRIPTION
## Sourcery 总结

错误修复:
- 在 `lxgw-wenkai-gb-web/style.css` 导入中添加缺失的闭合引号

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add missing closing quotation mark in the lxgw-wenkai-gb-web/style.css import

</details>