### PR TITLE
测试

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -91,12 +91,12 @@
 /* 导入 LXGW WenKai Screen*/
 :root {
   --vp-font-family-base: 'LXGW WenKai Screen';
-  --vp-font-family-default: 'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', "Noto Sans", 'Droid Sans', 'Helvetica Neue', sans-serif;
+  --vp-font-family-default: 'LXGW WenKai Screen';
   --vp-font-family-mono: 'LXGW WenKai Mono Screen';
   /* 定义一个 semibold 使用的字体栈，与 strong 相同 */
   --vp-font-family-semibold: var(--vp-font-family-default);
   /* 定义 semibold 的字重，通常对应 600 */
-  --vp-font-weight-semibold: 600;
+  --vp-font-weight-semibold: 800;
 }
 
 /* normal 字重文字使用 LXGW WenKai Screen */
@@ -107,10 +107,10 @@ span {
   font-weight: normal;
 }
 
-/* 当需要粗体（bold）时，回退到系统默认字体 */
+/* 当需要粗体（bold）时，加粗 */
 strong, b {
   font-family: var(--vp-font-family-default);
-  font-weight: bold; /* 通常对应 700 */
+  font-weight: bold; /* 通常对应 800 */
 }
 
 /* 为 semibold 定义样式 */


### PR DESCRIPTION
## Sourcery 总结

更新排版，独家使用 LXGW WenKai Screen 作为默认字体，并将半粗体和粗体字重增强至 800

增强功能：
- 将默认字体族堆栈替换为 LXGW WenKai Screen
- 将半粗体字重从 600 增加到 800
- 将粗体字重设置为 800，并移除粗体文本的系统回退

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update typography to exclusively use LXGW WenKai Screen as the default font and strengthen semibold and bold weights to 800

Enhancements:
- Replace the default font family stack with LXGW WenKai Screen
- Increase semibold font weight from 600 to 800
- Set bold font weight to 800 and remove the system fallback for bold text

</details>