### PR TITLE
测试粗体

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -110,7 +110,7 @@ span {
 /* 当需要粗体（bold）时，加粗 */
 strong, b {
   font-family: var(--vp-font-family-default);
-  font-weight: bold; /* 通常对应 800 */
+  font-weight: 800; /* 通常对应 800 */
 }
 
 /* 为 semibold 定义样式 */


### PR DESCRIPTION
## Sourcery 总结

改进：
- 为 `strong` 和 `b` 元素指定数字型 `font-weight` (800)，而不是使用“bold”关键词

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Specify numeric font-weight (800) instead of the 'bold' keyword for strong and b elements

</details>