### PR TITLE
,

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -21,7 +21,7 @@ export default defineConfig({
 	cleanUrls:true, // 在 URL 中去掉 .html 后缀
 markdown: {
   image: { lazyLoading: true },
-  lineNumbers: true // 启用行号于代码块
+  lineNumbers: true, // 启用行号于代码块
   config: (md) => {
       // 使用 lightbox plugin
       md.use(lightbox, {});


### PR DESCRIPTION
## Sourcery 总结

日常任务:
- 在 .vitepress/config.mts 文件中的 lineNumbers 属性后添加尾随逗号

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Add trailing comma after lineNumbers property in .vitepress/config.mts

</details>