### PR TITLE
typo

### DIFF
--- a/di-21-zhang-linux-jian-rong-ceng/di-21.5-jie-linux-jian-rong-ceng-ji-yu-archlinuxpacman.md
+++ b/di-21-zhang-linux-jian-rong-ceng/di-21.5-jie-linux-jian-rong-ceng-ji-yu-archlinuxpacman.md
@@ -2,7 +2,7 @@
 
 >**警告**
 >
->由于 Bug 287690 [sysutils/pacman: The archlinux flavor cannot be built or installed.](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287690)，本文暂不可用，若在六个月内（2025-04-01 日前）未得到解决将删除本文。
+>由于 Bug 287690 [sysutils/pacman: The archlinux flavor cannot be built or installed.](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287690)，本文暂不可用，若在六个月内（2026-04-01 日前）未得到解决将删除本文。
 
 ## 安装 Arch Linux 兼容层
 


### PR DESCRIPTION
## Sourcery 总结

文档：
- 将 Arch Linux 兼容层文档中的六个月移除截止日期从 2025-04-01 更新为 2026-04-01

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the six-month removal deadline from 2025-04-01 to 2026-04-01 in the Arch Linux compatibility layer document

</details>