### PR TITLE
移除无用 tex

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -189,13 +189,6 @@ export default defineConfig({
             "script",
             {
                 async: "",
-                src: "https://cdn.bootcdn.net/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.js",
-            },
-        ],
-        [
-            "script",
-            {
-                async: "",
                 src: "https://www.googletagmanager.com/gtag/js?id=G-GKTJ5MJJ58",
             },
         ],


### PR DESCRIPTION
## Sourcery 总结

日常维护：
- 从 Vitepress 配置中移除多余的 tex-mml-chtml MathJax 脚本引用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Remove redundant tex-mml-chtml MathJax script inclusion from Vitepress config

</details>