### PR TITLE
更新 config.mts

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -9,7 +9,7 @@ import {
 } from "vitepress-plugin-pagefind";
 import lightbox from "vitepress-plugin-lightbox";
 import { sri } from "vite-plugin-sri3";
-import { csp } from "vite-plugin-csp-guard";
+import csp from "vite-plugin-csp-guard";
 
 export default defineConfig({
     sitemap: {


### PR DESCRIPTION
## Sourcery 总结

错误修复:
- 更改 .vitepress/config.mts 中 csp 的导入，从命名导入更改为默认导入，针对 vite-plugin-csp-guard

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Change import of csp in .vitepress/config.mts from named to default import for vite-plugin-csp-guard

</details>