### PR TITLE
套用样式

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -83,25 +83,6 @@
 	}
 
 
-@media (min-width: 2388px)
-{
-}
-
-@media (min-width: 3840px)
-{
-	.VPNavBar .content
-	{
-		.VPNavBar {
-  padding-left: 25vw !important;
-		padding-right: 5vw !important;
-	}
-    /* 导航栏左侧最远至，为 0 时到达最左侧，覆盖原来的位置 */
-	padding-left: 5vw !important;
-    /* 导航栏右侧最远至，为 0 时到达最右侧，覆盖原来的位置 */
-    padding-right: 0 !important;
-}
-}
-
 }
 .outline-link
 {


### PR DESCRIPTION
## Sourcery 总结

清理 `custom.css`，移除废弃的高分辨率媒体查询和多余的导航栏内边距覆盖

改进：
- 移除空的 `@media (min-width:2388px)` 规则
- 移除多余的 `@media (min-width:3840px)` 块和嵌套的 `.VPNavBar` 内边距样式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up custom.css by removing obsolete high-resolution media queries and redundant navigation bar padding overrides

Enhancements:
- Remove empty @media (min-width:2388px) rule
- Remove redundant @media (min-width:3840px) block and nested .VPNavBar padding styles

</details>