### PR TITLE
no sudo

### DIFF
--- a/di-10-zhang-vpn-yu-dai-li/di-10.3-jie-clash.md
+++ b/di-10-zhang-vpn-yu-dai-li/di-10.3-jie-clash.md
@@ -71,7 +71,7 @@ $ ee .env
 - 运行启动脚本
 
 ```bash
-$ sudo bash start.sh
+# bash start.sh
 
 正在检测订阅地址...
 Clash订阅地址可访问！                                      [  OK  ]
@@ -145,7 +145,7 @@ $ cd clash-for-freebsd
 - 关闭服务
 
 ```bash
-$ sudo bash shutdown.sh
+# bash shutdown.sh
 
 服务关闭成功，请执行以下命令关闭系统代理：`proxy_off`
 


### PR DESCRIPTION
## Sourcery 总结

从 Clash 设置文档中的脚本执行指令中移除不必要的 sudo 前缀

文档：
- 更新了 start.sh 调用，以移除 sudo
- 更新了 shutdown.sh 调用，以移除 sudo

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unnecessary sudo prefixes from script execution instructions in the Clash setup documentation

Documentation:
- Updated start.sh invocation to drop sudo
- Updated shutdown.sh invocation to drop sudo

</details>