### PR TITLE
KDE 在 OpenBSD 下的音频解决

### DIFF
--- a/di-26-zhang-openbsd/di-26.5-jie-zhuo-mian-yu-qi-ta-ruan-jian.md
+++ b/di-26-zhang-openbsd/di-26.5-jie-zhuo-mian-yu-qi-ta-ruan-jian.md
@@ -289,6 +289,7 @@ OPTIONS_SET+=SNDIO
 - [KDE6 on OpenBSD](https://rsadowski.de/posts/2024-05-20-kde6-on-openbsd/)，作者的博客
 - [OpenBSD KDE Plasma Desktop](https://rsadowski.de/posts/2024-01-09-openbsd-kde/)，作者的博客
 - [NEW: KDE Plasma (x11/kde-plasma)](https://marc.info/?l=openbsd-ports&m=169391479324962&w=2)，初次移植成功的邮件通知
+- [Autospawning](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/Running/)，如何阻止加载 PulseAudio
 
 ## Firefox
 


### PR DESCRIPTION
## Sourcery 总结

添加解决 OpenBSD 上 KDE 音频问题的故障排除说明。

文档：
- 添加一个故障排除部分，详细说明如何在 /etc/pulse/client.conf 中禁用 PulseAudio，以解决在使用软件包时 KDE 没有声音的问题。
- 在 /etc/make.conf 中提供 ports 构建配置，以取消设置 PULSE 和 PULSEAUDIO 并为 KDE 音频设置 SNDIO。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add troubleshooting instructions for KDE audio issues on OpenBSD.

Documentation:
- Add a troubleshooting section detailing how to disable PulseAudio in /etc/pulse/client.conf to fix KDE no sound when using packages
- Provide ports build configuration in /etc/make.conf to unset PULSE and PULSEAUDIO and set SNDIO for KDE audio

</details>