### PR TITLE
补遗

### DIFF
--- a/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.2-jie-zfs.md
+++ b/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.2-jie-zfs.md
@@ -156,6 +156,10 @@ root@ykla:/home/ykla # zfs rollback -r zroot/var@test
 root@ykla:/home/ykla # zfs rollback -r zroot/var/log@test
 ```
 
+>**技巧**
+>
+>经过测试，若提前快照，单纯的 `# rm -rf /*` 亦可顺利恢复。若使用 UEFI，则需要自行按照其他章节一道恢复 efi 引导。
+
 - 销毁快照
 
 销毁快照（销毁的时候可以使用 `r` 递归销毁）：


### PR DESCRIPTION
## Sourcery 总结

增加一个文档提示，介绍如何使用 ZFS 快照从破坏性的 `rm -rf /*` 操作中恢复，并指出 UEFI 系统需要手动恢复 EFI。

文档:
- 解释说明在执行 `rm -rf /*` 之前创建快照可以实现完全恢复。
- 建议 UEFI 用户在恢复后手动恢复 EFI 启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a documentation tip on using ZFS snapshots to recover from a destructive rm -rf /* and note manual EFI restoration for UEFI systems

Documentation:
- Explain that taking a snapshot beforehand allows full recovery after rm -rf /*
- Advise UEFI users to manually restore the EFI boot after recovery

</details>