### PR TITLE
增补 bug 报告

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2025 年第四季度
 
+- 2025.11.8
+  - 由于 FreeBSD 的默认 ESP 不符合 UEFI 规范，提交 [Bug 290857 - bsdinstall: The ESP on FreeBSD Should Be FAT32 Instead of FAT16: D28897 Is Actually Ineffective ](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=290857)
 - 2025.11.5
   - “26.5 桌面和其他软件”新增故障排除，解决“KDE 无声音”
   - 增补贡献指南


### PR DESCRIPTION
## Sourcery 总结

文档:
- 添加 2025.11.8 变更日志条目，针对 Bug 290857，关于 FreeBSD 默认 ESP 在 UEFI 下要求 FAT32 的问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add 2025.11.8 changelog entry for Bug 290857 regarding FreeBSD default ESP requiring FAT32 under UEFI

</details>