### PR TITLE
删除无根据的话

### DIFF
--- a/di-2-zhang-an-zhuang-freebsd/di-2.5-jie-fen-pei-disk.md
+++ b/di-2-zhang-an-zhuang-freebsd/di-2.5-jie-fen-pei-disk.md
@@ -50,7 +50,7 @@ FreeBSD 14.2 RELEASE 的 `/` 分区支持 UFS 和 ZFS 两种文件系统。旧�
 
 ![](../.gitbook/assets/ins8.png)
 
-现代（近十几年内的）计算机应该选择 `GPT+UEFI`。请勿使用默认选项！这样会影响 4K 对齐，并产生一个 512KB 的 `freebsd-boot` 分区。
+现代（近十几年内的）计算机应该选择 `GPT+UEFI`。请勿使用默认选项！这样会产生一个 512KB 的 `freebsd-boot` 多余分区。
 
 较老的计算机（如 2013 年以前的）才应该选择选项 `GPT(BIOS)`——此默认选项同时兼容二者。
 


### PR DESCRIPTION
## Sourcery 总结

改进 FreeBSD 安装指南，以修正 GPT+UEFI 分区描述，并删除关于 4K 对齐的不准确说法。

文档：
- 重新措辞 GPT+UEFI 建议，以指出默认选项会生成一个不必要的 512KB freebsd-boot 分区。
- 删除关于 4K 对齐受默认分区选择影响的不受支持的说法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the FreeBSD installation guide to correct the description of GPT+UEFI partitioning and remove inaccurate claims about 4K alignment.

Documentation:
- Reword GPT+UEFI recommendation to indicate the default option produces an unnecessary 512KB freebsd-boot partition.
- Remove the unsupported statement about 4K alignment being affected by the default partition choice.

</details>