### PR TITLE
ykla-patch-1

### DIFF
--- a/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.2-jie-zfs.md
+++ b/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.2-jie-zfs.md
@@ -18,11 +18,11 @@ ZFS 最早源于 SUN 公司，是为了取代 Solaris（早期曾用名 SunOS）
 
 在 OpenSolaris 关停 3 年后（2013），ZFS 的主要开发者迁移到了 ZFSonLinux，后重命名成为如今的 OpenZFS。Illumos 版本 ZFS（其主要开发仍由 OpenZFS 推动）得到的功能更新日趋减少，FreeBSD 对该版本 ZFS 的维护难度也不断上升，当 ZFS 出现新功能时往往要先等待使其合并到 Illumos，再回溯到 FreeBSD 中。但 Illumos 的开发业已基本停滞。2018 年 8 月，FreeBSD 项目开始研究如何将 FreeBSD ZFS 由 Illumos 迁移到直接上游 OpenZFS。
 
-其实背后的主要原因在于 OpenZFS 新功能的主要开发商 Delphix 公司（Delphix 在 2024 年 2 月被 Perforce Software 收购），将其设备的操作系统从 Illumos 迁移到了 Linux。所以基本上放弃了对前者的投入。其理由是所有的云平台厂商和虚拟机平台几乎仅支持 Linux。
+“时来天地皆同力，运去英雄不自由。”（[唐]罗隐《筹笔驿》）OpenZFS 新功能的主要开发商 Delphix 公司（Delphix 在 2024 年 2 月被 Perforce Software 收购），将其设备的操作系统从 Illumos 迁移到了 Linux。所以基本上放弃了对前者的投入。其理由是所有的云平台厂商和虚拟机平台几乎仅支持 Linux。因此 Illumos 几乎再难得到投入。
 
 OpenZFS 是在 13.0（2021 年 4 月）引入 FreeBSD 的，“ZFS 的实现现由 OpenZFS 提供。[9e5787d2284e](https://cgit.freebsd.org/src/commit/?id=9e5787d2284e)（由 iXsystems 赞助）”取代了 OpenSolaris/illumos 版本的 ZFS。
 
-目前 OpenZFS 代码提交量第一位的成员属于美国劳伦斯利弗莫尔国家实验室（LLNL），由其主导开发。LLNL 的核心职责是确保美国国家核威慑的安全、可靠和有效。
+目前 OpenZFS 代码提交量的首位成员属于美国劳伦斯利弗莫尔国家实验室（LLNL），OpenZFS 由其主导开发。LLNL 的核心职责是确保美国国家核威慑的安全、可靠和有效。
 
 ### 参考文献
 


### PR DESCRIPTION
## Sourcery 总结

改进 ZFS 文档，通过添加一句古文来阐明 Delphix 从 Illumos 迁移到 Linux 的背景，澄清由此导致的对 Illumos 投入的不足，并润色措辞以强调 LLNL 在 OpenZFS 开发中的领导地位。

文档：
- 插入一句唐代古文，以此来阐述 Delphix 从 Illumos 转向 Linux 的转变，并指出对 Illumos 投入的日渐减少
- 阐明 Illumos 今后不太可能再获得新的贡献
- 重新措辞关于 LLNL 的句子，以强调其在 OpenZFS 开发中的主要领导作用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the ZFS documentation by adding a classical Chinese quote to contextualize Delphix’s migration from Illumos to Linux, clarifying the resulting lack of Illumos investment, and refining the phrasing to emphasize LLNL’s leadership in OpenZFS development.

Documentation:
- Insert a Tang dynasty quote to frame Delphix’s shift from Illumos to Linux and highlight Illumos’s diminishing investment
- Clarify that Illumos is now unlikely to receive further contributions
- Rephrase the sentence on LLNL to emphasize its primary leadership role in OpenZFS development

</details>