### PR TITLE
补遗

### DIFF
--- a/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.2-jie-zfs.md
+++ b/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.2-jie-zfs.md
@@ -4,7 +4,7 @@
 
 ## ZFS 简史与 Solaris 兴亡
 
-ZFS 最早源于 SUN 公司，是为了取代 Solaris（早期曾用名 SunOS）上的 UFS 文件系统所开发的。SunOS 和 BSD Unix 的关键开发者都是 Bill Joy，他也是 SUN 的创始人之一。SunOS 早期基于 BSD Unix 开发，后转向 SVR4（Unix System V Release 4，即转向与 AT&T 合作）。
+ZFS 最早源于 SUN 公司，是为了取代 Solaris（早期曾用名 SunOS）上的 UFS 文件系统所开发的。SunOS 和 BSD Unix 的关键开发者之一是 Bill Joy，他也是 SUN 的创始人之一。SunOS 早期基于 BSD Unix 开发，后转向 SVR4（Unix System V Release 4，即转向与 AT&T 合作）。
 
 ZFS 于 2005 年 11 月 1 日（revision 789）以 CDDL（Common Development and Distribution License, 通用开发及发行许可）开源到了 OpenSolaris 项目中。
 


### PR DESCRIPTION
## Sourcery 总结

修订 ZFS 历史文档，以澄清 Oracle Solaris/ZFS 命名，阐述 OpenZFS 的使命和兼容性限制，详细说明 Oracle Solaris 的维护生命周期以及 ZFS 迁移到 Oracle 存储设备的情况，重新排序相关内容以提高清晰度，并添加对 Oracle 终身支持政策的引用。

改进：
- 完善 Oracle Solaris 和 ZFS 的重命名及关闭时间表
- 解释 OpenZFS 统一开源开发的目标及其与 Oracle Solaris ZFS 的不兼容性
- 重新安排 Illumos 停滞讨论和 FreeBSD 迁移到上游 OpenZFS 的内容

文档：
- 添加 Oracle Solaris 11.4 支持生命周期和 ZFS 企业设备转变的详细信息
- 包含 Oracle 终身支持政策的链接

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过扩展和重组其历史叙述，阐明 Solaris/ZFS 命名变更和开发分歧，概述 OpenZFS 的目标和平台迁移，并添加 Oracle Solaris 和 ZFS 设备器的生命周期和策略参考，改进 ZFS 文档。

增强功能:
- 完善 ZFS 历史部分，追溯 SunOS 起源，并重命名以强调 Solaris 的兴衰
- 阐明 Oracle Solaris 和 ZFS 的重命名时间表以及向闭源开发的过渡
- 解释 OpenZFS 的统一开源使命及其与 Oracle Solaris ZFS 的不兼容性
- 重新组织对 illumos 停滞、FreeBSD 迁移到 OpenZFS 以及 Delphix 转向 Linux 的讨论
- 详细说明 Oracle Solaris 11.4 支持生命周期和 Oracle ZFS 设备器过渡，并附带策略参考
- 添加相关参考资料并重新排序内容以提高清晰度

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the ZFS documentation by expanding and reorganizing its historical narrative, clarifying Solaris/ZFS naming changes and development splits, outlining OpenZFS’s goals and platform migrations, and adding lifecycle and policy references for Oracle Solaris and ZFS appliances.

Enhancements:
- Refine ZFS history section with SunOS origins and rename it to emphasize Solaris rise and fall
- Clarify Oracle Solaris and ZFS renaming timeline and transition to closed-source development
- Explain OpenZFS’s unified open-source mission and its incompatibility with Oracle Solaris ZFS
- Reorganize discussion of illumos stagnation, FreeBSD’s migration to OpenZFS, and Delphix’s shift to Linux
- Detail Oracle Solaris 11.4 support lifecycle and Oracle ZFS appliance transition with policy reference
- Add relevant references and reorder content for improved clarity

</details>

</details>