### PR TITLE
补遗

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.3-jie-an-zhuang-kde.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.3-jie-an-zhuang-kde.md
@@ -126,7 +126,7 @@ KDE 旨在开发一套现代桌面系统，如果你觉得 KDE 界面很像 Wind
 ## 启动项设置
 
 ```sh
-# service dbus enable # 用于桌面环境的进程间通信
+# service dbus enable # 用于桌面环境的进程间通信，作为依赖自动安装的
 # service sddm enable # SDDM 登录管理器
 ```
 


### PR DESCRIPTION
## Sourcery 总结

文档：
- 注意：dbus 服务在 KDE 安装指南中作为桌面环境的依赖项自动安装。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Note that the dbus service is automatically installed as a dependency for desktop environments in the KDE installation guide

</details>