### PR TITLE
补遗

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -16,6 +16,8 @@ const RSS: RSSOptions = {
   title: 'FreeBSD 从入门到跑路',
   baseUrl,
   copyright: 'Copyright (c) 2021-present, FreeBSD 中文社区',
+  language: 'zh-cn',
+  favicon: 'https://docs.bsdcn.org/favicon.ico',
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Sourcery 总结

为 VitePress 配置添加缺失的语言和 favicon 设置

增强：
- 在 VitePress 配置中将网站语言设置为中文 (zh-cn)
- 在 VitePress 配置中添加默认的 favicon URL

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add missing language and favicon settings to the VitePress configuration

Enhancements:
- Set site language to Chinese (zh-cn) in VitePress config
- Add default favicon URL to VitePress config

</details>