### PR TITLE
移除 SRI

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -8,7 +8,6 @@ import {
     pagefindPlugin,
 } from "vitepress-plugin-pagefind";
 import lightbox from "vitepress-plugin-lightbox";
-import { sri } from "vite-plugin-sri3";
 import { RSSOptions, RssPlugin } from "vitepress-plugin-rss";
 
 const baseUrl = 'https://docs.bsdcn.org'
@@ -298,7 +297,6 @@ export default defineConfig({
                     collapsed: false,
                 },
             }),
-            sri(),
         ],
     },
 });


### PR DESCRIPTION
## Sourcery 总结

从 VitePress 配置中移除子资源完整性 (SRI) 插件

杂项：
- 从 VitePress 配置中删除 sri 导入
- 从配置的插件列表中移除 sri() 插件调用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove Subresource Integrity (SRI) plugin from the VitePress configuration

Chores:
- Delete sri import from the VitePress config
- Remove sri() plugin invocation from the config's plugin list

</details>