### PR TITLE
ykla-patch-1

### DIFF
--- a/di-22-zhang-bian-cheng-yu-kai-fa/di-22.15-jie-build-freebsd-on-linux.md
+++ b/di-22-zhang-bian-cheng-yu-kai-fa/di-22.15-jie-build-freebsd-on-linux.md
@@ -159,7 +159,7 @@ $ export CFLAGS="-DSTRERROR_R_CHAR_P=1"
 
 ### 32 位构建的问题
 
-待解决
+15.0 已经不再支持 32 位。
 
 ### Ubuntu 原生的 LLVM 工具链
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 在 FreeBSD-on-Linux 构建指南中明确说明，自 15.0 版本起不再支持 32 位构建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify in the FreeBSD-on-Linux build guide that 32-bit builds are no longer supported as of version 15.0.

</details>