### PR TITLE
i386 和 amd64 共用的机器相关配置

### DIFF
--- a/di-22-zhang-bian-cheng-yu-kai-fa/di-22.16-kernel-conf.md
+++ b/di-22-zhang-bian-cheng-yu-kai-fa/di-22.16-kernel-conf.md
@@ -933,7 +933,7 @@ device		imcsmb
 系统管理总线（SMB）。
 
 支持的 SMBus 接口：
-- imcsmb- 集成内存控制器 (iMC) SMBus 控制器。
+- imcsmb：集成内存控制器 (iMC) SMBus 控制器。
  - 支持平台：Sandy Bridge-至强、Ivy Bridge-至强、Haswell-至强、Broadwell-至强处理器
 
 ```ini


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 为 i386 和 amd64 共享内核配置选项添加了详尽说明，其中包括 DTrace、SMP、兼容性、网络、ACPI、总线、存储、输入/显示设备、RAID、无线固件、NTB、传感器、看门狗以及虚拟化驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add extensive explanations for i386 and amd64 shared kernel configuration options, including DTrace, SMP, compatibility, networking, ACPI, buses, storage, input/display devices, RAID, wireless firmware, NTB, sensors, watchdogs, and virtualization drivers.

</details>