### PR TITLE
增补机器无关的内核选项 28%

### DIFF
--- a/di-22-zhang-bian-cheng-yu-kai-fa/di-22.16-kernel-conf.md
+++ b/di-22-zhang-bian-cheng-yu-kai-fa/di-22.16-kernel-conf.md
@@ -23,7 +23,7 @@
 - `LINT-NOINET`：LINT 文件，不到五行，禁用了 [INET(4)](https://man.freebsd.org/cgi/man.cgi?query=inet&sektion=4&man)（IPv4）。LINT 文件，参见 [Eliminate building LINT makefiles](https://reviews.freebsd.org/D26540)。
 - `LINT-NOINET6`：LINT 文件，不到五行，禁用了 [INET(6)](https://man.freebsd.org/cgi/man.cgi?query=inet6&sektion=4&man)（IPv6）。LINT 文件，参见 [Eliminate building LINT makefiles](https://reviews.freebsd.org/D26540)。
 - `LINT-NOIP`：LINT 文件，不到三十行，禁用了 IP 协议相关（IPv4、IPv6、TLS 等）。LINT 文件，参见 [Eliminate building LINT makefiles](https://reviews.freebsd.org/D26540)。
-- `LINT-NOVIMAGE`：调试开发用。LINT 文件，不到五行，禁用了 [VIMAGE (9)](https://man.freebsd.org/cgi/man.cgi?query=vimage&sektion=9&manpath=freebsd-release-ports)（实际上是 VNET(9) 的别名，网络子系统虚拟化基础设施）。参见 [sys: add LINT-NOVIMAGE](https://reviews.freebsd.org/D50780)
+- `LINT-NOVIMAGE`：调试开发用。LINT 文件，不到五行，禁用了 [VIMAGE (9)](https://man.freebsd.org/cgi/man.cgi?query=vimage&sektion=9)（实际上是 VNET(9) 的别名，网络子系统虚拟化基础设施）。参见 [sys: add LINT-NOVIMAGE](https://reviews.freebsd.org/D50780)
 - `MINIMAL`：FreeBSD/amd64 中最常用的最简内核配置选项。160 余行。
 - `MINIMAL-NODEBUG`：等同于 GENERIC-NODEBUG，只不过是 `MINIMAL` 版本的。不到 15 行。
 
@@ -1616,7 +1616,7 @@ options 	COMPILING_LINT
 options 	STACK
 ```
 
-STACK 将启用 [stack(9)](https://man.freebsd.org/cgi/man.cgi?query=stack&sektion=9&manpath=FreeBSD+8.2-RELEASE) 功能，可捕获内核栈。若内核编译中包含 [DDB(4)](https://man.freebsd.org/cgi/man.cgi?ddb(4))，[stack(9)](https://man.freebsd.org/cgi/man.cgi?query=stack&sektion=9&manpath=FreeBSD+8.2-RELEASE) 也会被自动编译进内核。
+STACK 将启用 [stack(9)](https://man.freebsd.org/cgi/man.cgi?query=stack&sektion=9) 功能，可捕获内核栈。若内核编译中包含 [DDB(4)](https://man.freebsd.org/cgi/man.cgi?ddb(4))，[stack(9)](https://man.freebsd.org/cgi/man.cgi?query=stack&sektion=9) 也会被自动编译进内核。
 
 ```ini
 options 	NUM_CORE_FILES=5


### PR DESCRIPTION
## Summary by Sourcery

记录更多与机器无关的 FreeBSD 内核配置选项，并在内核配置章节中澄清相关描述。

Documentation:
- 澄清现有 LINT 和温度传感器内核选项的描述和措辞。
- 为广泛的调试、跟踪、诊断和回归测试相关的内核选项添加详细说明（例如：SYSCTL_DEBUG、TEXTDUMP、MALLOC/memguard、KTRACE/KTR、INVARIANTS、DIAGNOSTIC、REGRESSION、TSLOG）。
- 记录通过 hwpmc 及相关钩子进行性能监控的配置方法。
- 扩展与网络和协议栈相关的内核选项文档，包括 TCP 拥塞控制、IPsec、TLS、SCTP、Netlink、SMB/NETSMB、libalias、OFED/SDP/IPOIB，以及 ALTQ 及其调度器。
- 改进对内核配置文件格式、术语（例如 device/options/hints 条目）的指导，并交叉引用相关的 man 手册页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional machine-independent FreeBSD kernel configuration options and clarify related descriptions in the kernel configuration chapter.

Documentation:
- Clarify descriptions and wording for existing LINT and temperature sensor kernel options.
- Add detailed explanations for a wide range of debugging, tracing, diagnostics, and regression-testing kernel options (e.g., SYSCTL_DEBUG, TEXTDUMP, MALLOC/memguard, KTRACE/KTR, INVARIANTS, DIAGNOSTIC, REGRESSION, TSLOG).
- Document performance monitoring configuration via hwpmc and related hooks.
- Expand documentation of networking and protocol-stack-related kernel options, including TCP congestion control, IPsec, TLS, SCTP, Netlink, SMB/NETSMB, libalias, OFED/SDP/IPOIB, and ALTQ and its schedulers.
- Improve guidance on kernel config file formatting, terminology (e.g., device/options/hints entries), and cross-reference relevant man pages.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

记录更多与机器无关的 FreeBSD 内核配置选项，并在内核配置章节中澄清相关描述。

Documentation:
- 澄清现有 LINT 和温度传感器内核选项的描述和措辞。
- 为广泛的调试、跟踪、诊断和回归测试相关的内核选项添加详细说明（例如：SYSCTL_DEBUG、TEXTDUMP、MALLOC/memguard、KTRACE/KTR、INVARIANTS、DIAGNOSTIC、REGRESSION、TSLOG）。
- 记录通过 hwpmc 及相关钩子进行性能监控的配置方法。
- 扩展与网络和协议栈相关的内核选项文档，包括 TCP 拥塞控制、IPsec、TLS、SCTP、Netlink、SMB/NETSMB、libalias、OFED/SDP/IPOIB，以及 ALTQ 及其调度器。
- 改进对内核配置文件格式、术语（例如 device/options/hints 条目）的指导，并交叉引用相关的 man 手册页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional machine-independent FreeBSD kernel configuration options and clarify related descriptions in the kernel configuration chapter.

Documentation:
- Clarify descriptions and wording for existing LINT and temperature sensor kernel options.
- Add detailed explanations for a wide range of debugging, tracing, diagnostics, and regression-testing kernel options (e.g., SYSCTL_DEBUG, TEXTDUMP, MALLOC/memguard, KTRACE/KTR, INVARIANTS, DIAGNOSTIC, REGRESSION, TSLOG).
- Document performance monitoring configuration via hwpmc and related hooks.
- Expand documentation of networking and protocol-stack-related kernel options, including TCP congestion control, IPsec, TLS, SCTP, Netlink, SMB/NETSMB, libalias, OFED/SDP/IPOIB, and ALTQ and its schedulers.
- Improve guidance on kernel config file formatting, terminology (e.g., device/options/hints entries), and cross-reference relevant man pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

记录更多与机器无关的 FreeBSD 内核配置选项，并在内核配置章节中澄清相关描述。

Documentation:
- 澄清现有 LINT 和温度传感器内核选项的描述和措辞。
- 为广泛的调试、跟踪、诊断和回归测试相关的内核选项添加详细说明（例如：SYSCTL_DEBUG、TEXTDUMP、MALLOC/memguard、KTRACE/KTR、INVARIANTS、DIAGNOSTIC、REGRESSION、TSLOG）。
- 记录通过 hwpmc 及相关钩子进行性能监控的配置方法。
- 扩展与网络和协议栈相关的内核选项文档，包括 TCP 拥塞控制、IPsec、TLS、SCTP、Netlink、SMB/NETSMB、libalias、OFED/SDP/IPOIB，以及 ALTQ 及其调度器。
- 改进对内核配置文件格式、术语（例如 device/options/hints 条目）的指导，并交叉引用相关的 man 手册页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional machine-independent FreeBSD kernel configuration options and clarify related descriptions in the kernel configuration chapter.

Documentation:
- Clarify descriptions and wording for existing LINT and temperature sensor kernel options.
- Add detailed explanations for a wide range of debugging, tracing, diagnostics, and regression-testing kernel options (e.g., SYSCTL_DEBUG, TEXTDUMP, MALLOC/memguard, KTRACE/KTR, INVARIANTS, DIAGNOSTIC, REGRESSION, TSLOG).
- Document performance monitoring configuration via hwpmc and related hooks.
- Expand documentation of networking and protocol-stack-related kernel options, including TCP congestion control, IPsec, TLS, SCTP, Netlink, SMB/NETSMB, libalias, OFED/SDP/IPOIB, and ALTQ and its schedulers.
- Improve guidance on kernel config file formatting, terminology (e.g., device/options/hints entries), and cross-reference relevant man pages.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

记录更多与机器无关的 FreeBSD 内核配置选项，并在内核配置章节中澄清相关描述。

Documentation:
- 澄清现有 LINT 和温度传感器内核选项的描述和措辞。
- 为广泛的调试、跟踪、诊断和回归测试相关的内核选项添加详细说明（例如：SYSCTL_DEBUG、TEXTDUMP、MALLOC/memguard、KTRACE/KTR、INVARIANTS、DIAGNOSTIC、REGRESSION、TSLOG）。
- 记录通过 hwpmc 及相关钩子进行性能监控的配置方法。
- 扩展与网络和协议栈相关的内核选项文档，包括 TCP 拥塞控制、IPsec、TLS、SCTP、Netlink、SMB/NETSMB、libalias、OFED/SDP/IPOIB，以及 ALTQ 及其调度器。
- 改进对内核配置文件格式、术语（例如 device/options/hints 条目）的指导，并交叉引用相关的 man 手册页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional machine-independent FreeBSD kernel configuration options and clarify related descriptions in the kernel configuration chapter.

Documentation:
- Clarify descriptions and wording for existing LINT and temperature sensor kernel options.
- Add detailed explanations for a wide range of debugging, tracing, diagnostics, and regression-testing kernel options (e.g., SYSCTL_DEBUG, TEXTDUMP, MALLOC/memguard, KTRACE/KTR, INVARIANTS, DIAGNOSTIC, REGRESSION, TSLOG).
- Document performance monitoring configuration via hwpmc and related hooks.
- Expand documentation of networking and protocol-stack-related kernel options, including TCP congestion control, IPsec, TLS, SCTP, Netlink, SMB/NETSMB, libalias, OFED/SDP/IPOIB, and ALTQ and its schedulers.
- Improve guidance on kernel config file formatting, terminology (e.g., device/options/hints entries), and cross-reference relevant man pages.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

记录更多与机器无关的 FreeBSD 内核配置选项，并在内核配置章节中澄清相关描述。

Documentation:
- 澄清现有 LINT 和温度传感器内核选项的描述和措辞。
- 为广泛的调试、跟踪、诊断和回归测试相关的内核选项添加详细说明（例如：SYSCTL_DEBUG、TEXTDUMP、MALLOC/memguard、KTRACE/KTR、INVARIANTS、DIAGNOSTIC、REGRESSION、TSLOG）。
- 记录通过 hwpmc 及相关钩子进行性能监控的配置方法。
- 扩展与网络和协议栈相关的内核选项文档，包括 TCP 拥塞控制、IPsec、TLS、SCTP、Netlink、SMB/NETSMB、libalias、OFED/SDP/IPOIB，以及 ALTQ 及其调度器。
- 改进对内核配置文件格式、术语（例如 device/options/hints 条目）的指导，并交叉引用相关的 man 手册页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional machine-independent FreeBSD kernel configuration options and clarify related descriptions in the kernel configuration chapter.

Documentation:
- Clarify descriptions and wording for existing LINT and temperature sensor kernel options.
- Add detailed explanations for a wide range of debugging, tracing, diagnostics, and regression-testing kernel options (e.g., SYSCTL_DEBUG, TEXTDUMP, MALLOC/memguard, KTRACE/KTR, INVARIANTS, DIAGNOSTIC, REGRESSION, TSLOG).
- Document performance monitoring configuration via hwpmc and related hooks.
- Expand documentation of networking and protocol-stack-related kernel options, including TCP congestion control, IPsec, TLS, SCTP, Netlink, SMB/NETSMB, libalias, OFED/SDP/IPOIB, and ALTQ and its schedulers.
- Improve guidance on kernel config file formatting, terminology (e.g., device/options/hints entries), and cross-reference relevant man pages.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

记录更多与机器无关的 FreeBSD 内核配置选项，并在内核配置章节中澄清相关描述。

Documentation:
- 澄清现有 LINT 和温度传感器内核选项的描述和措辞。
- 为广泛的调试、跟踪、诊断和回归测试相关的内核选项添加详细说明（例如：SYSCTL_DEBUG、TEXTDUMP、MALLOC/memguard、KTRACE/KTR、INVARIANTS、DIAGNOSTIC、REGRESSION、TSLOG）。
- 记录通过 hwpmc 及相关钩子进行性能监控的配置方法。
- 扩展与网络和协议栈相关的内核选项文档，包括 TCP 拥塞控制、IPsec、TLS、SCTP、Netlink、SMB/NETSMB、libalias、OFED/SDP/IPOIB，以及 ALTQ 及其调度器。
- 改进对内核配置文件格式、术语（例如 device/options/hints 条目）的指导，并交叉引用相关的 man 手册页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional machine-independent FreeBSD kernel configuration options and clarify related descriptions in the kernel configuration chapter.

Documentation:
- Clarify descriptions and wording for existing LINT and temperature sensor kernel options.
- Add detailed explanations for a wide range of debugging, tracing, diagnostics, and regression-testing kernel options (e.g., SYSCTL_DEBUG, TEXTDUMP, MALLOC/memguard, KTRACE/KTR, INVARIANTS, DIAGNOSTIC, REGRESSION, TSLOG).
- Document performance monitoring configuration via hwpmc and related hooks.
- Expand documentation of networking and protocol-stack-related kernel options, including TCP congestion control, IPsec, TLS, SCTP, Netlink, SMB/NETSMB, libalias, OFED/SDP/IPOIB, and ALTQ and its schedulers.
- Improve guidance on kernel config file formatting, terminology (e.g., device/options/hints entries), and cross-reference relevant man pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

记录更多与机器无关的 FreeBSD 内核配置选项，并在内核配置章节中澄清相关描述。

Documentation:
- 澄清现有 LINT 和温度传感器内核选项的描述和措辞。
- 为广泛的调试、跟踪、诊断和回归测试相关的内核选项添加详细说明（例如：SYSCTL_DEBUG、TEXTDUMP、MALLOC/memguard、KTRACE/KTR、INVARIANTS、DIAGNOSTIC、REGRESSION、TSLOG）。
- 记录通过 hwpmc 及相关钩子进行性能监控的配置方法。
- 扩展与网络和协议栈相关的内核选项文档，包括 TCP 拥塞控制、IPsec、TLS、SCTP、Netlink、SMB/NETSMB、libalias、OFED/SDP/IPOIB，以及 ALTQ 及其调度器。
- 改进对内核配置文件格式、术语（例如 device/options/hints 条目）的指导，并交叉引用相关的 man 手册页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional machine-independent FreeBSD kernel configuration options and clarify related descriptions in the kernel configuration chapter.

Documentation:
- Clarify descriptions and wording for existing LINT and temperature sensor kernel options.
- Add detailed explanations for a wide range of debugging, tracing, diagnostics, and regression-testing kernel options (e.g., SYSCTL_DEBUG, TEXTDUMP, MALLOC/memguard, KTRACE/KTR, INVARIANTS, DIAGNOSTIC, REGRESSION, TSLOG).
- Document performance monitoring configuration via hwpmc and related hooks.
- Expand documentation of networking and protocol-stack-related kernel options, including TCP congestion control, IPsec, TLS, SCTP, Netlink, SMB/NETSMB, libalias, OFED/SDP/IPOIB, and ALTQ and its schedulers.
- Improve guidance on kernel config file formatting, terminology (e.g., device/options/hints entries), and cross-reference relevant man pages.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

记录更多与机器无关的 FreeBSD 内核配置选项，并在内核配置章节中澄清相关描述。

Documentation:
- 澄清现有 LINT 和温度传感器内核选项的描述和措辞。
- 为广泛的调试、跟踪、诊断和回归测试相关的内核选项添加详细说明（例如：SYSCTL_DEBUG、TEXTDUMP、MALLOC/memguard、KTRACE/KTR、INVARIANTS、DIAGNOSTIC、REGRESSION、TSLOG）。
- 记录通过 hwpmc 及相关钩子进行性能监控的配置方法。
- 扩展与网络和协议栈相关的内核选项文档，包括 TCP 拥塞控制、IPsec、TLS、SCTP、Netlink、SMB/NETSMB、libalias、OFED/SDP/IPOIB，以及 ALTQ 及其调度器。
- 改进对内核配置文件格式、术语（例如 device/options/hints 条目）的指导，并交叉引用相关的 man 手册页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional machine-independent FreeBSD kernel configuration options and clarify related descriptions in the kernel configuration chapter.

Documentation:
- Clarify descriptions and wording for existing LINT and temperature sensor kernel options.
- Add detailed explanations for a wide range of debugging, tracing, diagnostics, and regression-testing kernel options (e.g., SYSCTL_DEBUG, TEXTDUMP, MALLOC/memguard, KTRACE/KTR, INVARIANTS, DIAGNOSTIC, REGRESSION, TSLOG).
- Document performance monitoring configuration via hwpmc and related hooks.
- Expand documentation of networking and protocol-stack-related kernel options, including TCP congestion control, IPsec, TLS, SCTP, Netlink, SMB/NETSMB, libalias, OFED/SDP/IPOIB, and ALTQ and its schedulers.
- Improve guidance on kernel config file formatting, terminology (e.g., device/options/hints entries), and cross-reference relevant man pages.

</details>

</details>

</details>

</details>