### PR TITLE
更新 CHANGELOG，记录机器无关内核选项覆盖率 69%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 2025 年第四季度
 
+- 2025.11.25
+  - “22.16 FreeBSD 内核配置选项”引入 69% 的机器无关的内核选项（按行数计）
+    - 根据编纂发现，提交 [NOTES: Fix a typo in a comments](https://github.com/freebsd/freebsd-src/pull/1899)
 - 2025.11.24
   - “22.16 FreeBSD 内核配置选项”引入 56% 的机器无关的内核选项（按行数计）
 - 2025.11.23


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 添加一条日期为 2025-11-25 的更新日志条目，总结与机器无关的 FreeBSD 内核配置选项覆盖范围的扩展，并引用相关的上游拼写错误修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a 2025-11-25 changelog entry summarizing the increased coverage of machine-independent FreeBSD kernel configuration options and referencing a related upstream typo fix.

</details>