### PR TITLE
规范 di-24.3 内核选项章节标题层级与措辞

### DIFF
--- a/di-24-zhang-kernel/di-24.3-kernel-mi.md
+++ b/di-24-zhang-kernel/di-24.3-kernel-mi.md
@@ -4065,9 +4065,7 @@ device		fwip
 基于火线的 IP 协议（RFC2734 和 RFC3146）。
 
 
-
-
-#### dcons 哑终端支持（简易控制台设备）
+### dcons 哑终端支持（简易控制台设备）
 
 ```sh
 device		dcons
@@ -4107,7 +4105,7 @@ options 	DCONS_FORCE_GDB=1
 强制将哑终端设置为 GDB 设备。
 
 
-#### 加密子系统
+### 加密子系统
 
 此版本是从 OpenBSD 移植的加密框架。当配置 IPSEC 或拥有硬件加密设备时需包含此模块，可加速链接到 OpenSSL 的用户应用程序。
 
@@ -4161,7 +4159,7 @@ options 	SAFE_RNDTEST
 启用 [rndtest(4)](https://man.freebsd.org/cgi/man.cgi?query=rndtest&apropos=0&sektion=0)（FIPS 140-2 随机数生成器测试监视器）支持。
 
 
-#### 嵌入式系统
+### 嵌入式系统
 
 
 ```sh
@@ -4170,7 +4168,7 @@ options 	INIT_PATH=/sbin/init:/rescue/init
 
 嵌入式系统可能需要运行 init 以外的程序。
 
-##### 调试选项
+#### 调试选项
 
 
 ```sh
@@ -4205,7 +4203,7 @@ options 	VERBOSE_SYSINIT
 
 使 `mi_startup()` 执行的 SYSINIT 过程输出详细信息。该功能在移植新架构时非常实用。若同时启用了 DDB 调试器，将显示函数名称而非地址。若定义值为 `0`，则详细输出代码会被编译进内核但默认禁用，可通过可调参数 `debug.verbose_sysinit=1` 启用。
 
-#### SYSV IPC 内核参数
+### SYSV IPC 内核参数
 
 
 ```sh
@@ -4361,7 +4359,7 @@ options 	NBUF=512
 options 	SC_DEBUG_LEVEL=5
 ```
 
-Syscons 调试级别。
+syscons 调试级别。
 
 ```sh
 options 	SC_RENDER_DEBUG
@@ -4387,7 +4385,7 @@ options 	KSTACK_USAGE_PROF
 
 跟踪线程在内核中使用的最大栈空间。
 
-#### Adaptec 阵列控制器驱动选项
+### Adaptec 阵列控制器驱动选项
 
 ```sh
 options 	AAC_DEBUG	
@@ -4417,7 +4415,7 @@ options 	MAXFILES=999
 
 未有文档描述的 lint 检查选项。
 
-#### 随机数生成器
+### 随机数生成器
 
 ```sh
 options 	RANDOM_FENESTRASX
@@ -4472,7 +4470,7 @@ options         IMGACT_BINMISC
 
 用于通过 QEMU 等模拟器启用应用程序执行的模块。
 
-#### zlib 输入/输出流支持
+### zlib 输入/输出流支持
 
 ```sh
 options 	GZIO
@@ -4481,7 +4479,7 @@ options 	GZIO
 此选项用于支持生成经过压缩的核心转储文件。
 
 
-#### zstd
+### zstd
 
 ```sh
 options 	ZSTDIO
@@ -4489,7 +4487,7 @@ options 	ZSTDIO
 
 此选项用于支持 Zstd 压缩的核心转储文件、GEOM_UZIP 镜像，并且在静态链接时是 ZFS 文件系统必需的组件。
 
-#### BHND(4) 驱动
+### BHND(4) 驱动
 
 ```sh
 options 	BHND_LOGLEVEL
@@ -4497,7 +4495,7 @@ options 	BHND_LOGLEVEL
 
 日志记录阈值级别。
 
-####  evdev 接口
+###  evdev 接口
 
 ```sh
 device		evdev
@@ -4539,7 +4537,7 @@ options 	EKCD
 
 加密的内核崩溃转储
 
-#### 串行外设接口（SPI）
+### 串行外设接口（SPI）
 
 ```sh
 device		spibus
@@ -4573,7 +4571,7 @@ options 	SPIGEN_LEGACY_CDEVNAME
 
 spigen 的传统设备名称：为 `/dev/spigenX.Y` 设备启用传统的别名 `/dev/spigenN`。
 
-#### 压缩支持
+### 压缩支持
 
 ```sh
 device		zlib
@@ -4588,7 +4586,7 @@ device		xz
 xz_embedded LZMA 解压缩库。
 
 
-#### 内核 stats(3) 支持
+### 内核 stats(3) 支持
 
 ```sh
 options 	STATS
@@ -4596,7 +4594,7 @@ options 	STATS
 
 内核级 stats(3) 支持。
 
-####  文件系统监控
+###  文件系统监控
 
 ```sh
 device		filemon
@@ -4604,7 +4602,7 @@ device		filemon
 
 make(1) 元（meta）模式的文件监控。
 
-#### 英特尔 QuickAssist (QAT) 驱动程序
+### 英特尔 QuickAssist (QAT) 驱动程序
 
 ```sh
 options		QAT_DISABLE_SAFE_DC_MODE


### PR DESCRIPTION
## Summary by Sourcery

规范化 `di-24.3-kernel-mi.md` 文档章节的层级结构和措辞。

文档修改内容：
- 将若干小节标题（例如 `dcons`、加密子系统、嵌入式系统、驱动和压缩相关章节）提升为更高一级的标题层级，以保持结构一致。
- 统一 `syscons` 调试级别说明中的措辞和大小写格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize section hierarchy and wording in the di-24.3-kernel-mi.md documentation chapter.

Documentation:
- Promote several subsection headings (e.g., dcons, 加密子系统, 嵌入式系统, 驱动和压缩相关章节) to a higher heading level for consistent structure.
- Standardize wording and capitalization in the syscons debug level description.

</details>