### PR TITLE
增补 RISC-V 机器相关内核配置与设备选项文档

### DIFF
--- a/di-24-zhang-kernel/di-24.2-kernel-md.md
+++ b/di-24-zhang-kernel/di-24.2-kernel-md.md
@@ -1079,17 +1079,17 @@ MMC/SD/SDIO 卡槽支持。
 device dtrace
 ```
 
-dtrace 核心。
+DTrace 核心。
 
 >**注意**
 >
->dtrace 会把 CDDL 许可协议授权的组件引入内核。
+>选项 `dtrace` 会把 CDDL 许可协议授权的组件引入内核。
 
 ```sh
 device dtraceall
 ```
 
-内置所有 dtrace 模块。
+内置所有 DTrace 模块。
 
 ### 串行（COM）端口
 


### PR DESCRIPTION
## Summary by Sourcery

在内核配置指南中记录 RISC-V 特定的内核配置选项和设备支持。

文档：
- 在内核配置指南中描述 RISC-V CPU 选择、调试/DTrace/CTF 选项、`printf` 缓冲以及相关内核选项。
- 记录可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 特定的设备驱动程序。
- 记录 RISC-V 扁平设备树（flattened device tree）支持选项，并明确说明已禁用的传统兼容性、芯片组探测、声音（sound）、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document RISC-V-specific kernel configuration options and device support in the kernel configuration guide.

Documentation:
- Describe RISC-V CPU selection, debugging/DTrace/CTF options, printf buffering, and related kernel options in the kernel configuration guide.
- Document available RISC-V console, MMC/SD, UART, RTC, Ethernet, DMA, SPI, power management, and SiFive-specific device drivers.
- Record RISC-V flattened device tree support options and explicitly note disabled legacy compatibility, chipset probing, sound, hwpmc, and atomic-operation-dependent drivers.

</details>

文档更新内容：
- 增加对 RISC-V CPU 选择、调试、DTrace/CTF、`printf` 缓冲以及相关内核选项的说明。
- 描述可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 专用设备驱动程序。
- 记录 RISC-V 扁平化设备树（flattened device tree）支持选项，并明确注明已禁用的传统兼容性、芯片组探测、声音、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在内核配置指南中记录 RISC-V 特定的内核配置选项和设备支持。

文档：
- 在内核配置指南中描述 RISC-V CPU 选择、调试/DTrace/CTF 选项、`printf` 缓冲以及相关内核选项。
- 记录可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 特定的设备驱动程序。
- 记录 RISC-V 扁平设备树（flattened device tree）支持选项，并明确说明已禁用的传统兼容性、芯片组探测、声音（sound）、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document RISC-V-specific kernel configuration options and device support in the kernel configuration guide.

Documentation:
- Describe RISC-V CPU selection, debugging/DTrace/CTF options, printf buffering, and related kernel options in the kernel configuration guide.
- Document available RISC-V console, MMC/SD, UART, RTC, Ethernet, DMA, SPI, power management, and SiFive-specific device drivers.
- Record RISC-V flattened device tree support options and explicitly note disabled legacy compatibility, chipset probing, sound, hwpmc, and atomic-operation-dependent drivers.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在内核配置指南中记录 RISC-V 特定的内核配置选项和设备支持。

文档：
- 在内核配置指南中描述 RISC-V CPU 选择、调试/DTrace/CTF 选项、`printf` 缓冲以及相关内核选项。
- 记录可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 特定的设备驱动程序。
- 记录 RISC-V 扁平设备树（flattened device tree）支持选项，并明确说明已禁用的传统兼容性、芯片组探测、声音（sound）、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document RISC-V-specific kernel configuration options and device support in the kernel configuration guide.

Documentation:
- Describe RISC-V CPU selection, debugging/DTrace/CTF options, printf buffering, and related kernel options in the kernel configuration guide.
- Document available RISC-V console, MMC/SD, UART, RTC, Ethernet, DMA, SPI, power management, and SiFive-specific device drivers.
- Record RISC-V flattened device tree support options and explicitly note disabled legacy compatibility, chipset probing, sound, hwpmc, and atomic-operation-dependent drivers.

</details>

文档更新内容：
- 增加对 RISC-V CPU 选择、调试、DTrace/CTF、`printf` 缓冲以及相关内核选项的说明。
- 描述可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 专用设备驱动程序。
- 记录 RISC-V 扁平化设备树（flattened device tree）支持选项，并明确注明已禁用的传统兼容性、芯片组探测、声音、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在内核配置指南中记录 RISC-V 特定的内核配置选项和设备支持。

文档：
- 在内核配置指南中描述 RISC-V CPU 选择、调试/DTrace/CTF 选项、`printf` 缓冲以及相关内核选项。
- 记录可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 特定的设备驱动程序。
- 记录 RISC-V 扁平设备树（flattened device tree）支持选项，并明确说明已禁用的传统兼容性、芯片组探测、声音（sound）、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document RISC-V-specific kernel configuration options and device support in the kernel configuration guide.

Documentation:
- Describe RISC-V CPU selection, debugging/DTrace/CTF options, printf buffering, and related kernel options in the kernel configuration guide.
- Document available RISC-V console, MMC/SD, UART, RTC, Ethernet, DMA, SPI, power management, and SiFive-specific device drivers.
- Record RISC-V flattened device tree support options and explicitly note disabled legacy compatibility, chipset probing, sound, hwpmc, and atomic-operation-dependent drivers.

</details>

</details>

</details>

文档内容：
- 在内核配置指南中新增对 RISC-V CPU 选择、调试/CTF/DTrace 相关选项，以及 `printf` 缓冲设置的说明。
- 在文档中描述 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 专用设备驱动程序。
- 记录 RISC-V 特定的展平设备树（flattened device tree）支持选项，以及显式禁用的旧版兼容性、芯片组探测、声音、hwpmc 和某些依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在内核配置指南中记录 RISC-V 特定的内核配置选项和设备支持。

文档：
- 在内核配置指南中描述 RISC-V CPU 选择、调试/DTrace/CTF 选项、`printf` 缓冲以及相关内核选项。
- 记录可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 特定的设备驱动程序。
- 记录 RISC-V 扁平设备树（flattened device tree）支持选项，并明确说明已禁用的传统兼容性、芯片组探测、声音（sound）、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document RISC-V-specific kernel configuration options and device support in the kernel configuration guide.

Documentation:
- Describe RISC-V CPU selection, debugging/DTrace/CTF options, printf buffering, and related kernel options in the kernel configuration guide.
- Document available RISC-V console, MMC/SD, UART, RTC, Ethernet, DMA, SPI, power management, and SiFive-specific device drivers.
- Record RISC-V flattened device tree support options and explicitly note disabled legacy compatibility, chipset probing, sound, hwpmc, and atomic-operation-dependent drivers.

</details>

文档更新内容：
- 增加对 RISC-V CPU 选择、调试、DTrace/CTF、`printf` 缓冲以及相关内核选项的说明。
- 描述可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 专用设备驱动程序。
- 记录 RISC-V 扁平化设备树（flattened device tree）支持选项，并明确注明已禁用的传统兼容性、芯片组探测、声音、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在内核配置指南中记录 RISC-V 特定的内核配置选项和设备支持。

文档：
- 在内核配置指南中描述 RISC-V CPU 选择、调试/DTrace/CTF 选项、`printf` 缓冲以及相关内核选项。
- 记录可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 特定的设备驱动程序。
- 记录 RISC-V 扁平设备树（flattened device tree）支持选项，并明确说明已禁用的传统兼容性、芯片组探测、声音（sound）、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document RISC-V-specific kernel configuration options and device support in the kernel configuration guide.

Documentation:
- Describe RISC-V CPU selection, debugging/DTrace/CTF options, printf buffering, and related kernel options in the kernel configuration guide.
- Document available RISC-V console, MMC/SD, UART, RTC, Ethernet, DMA, SPI, power management, and SiFive-specific device drivers.
- Record RISC-V flattened device tree support options and explicitly note disabled legacy compatibility, chipset probing, sound, hwpmc, and atomic-operation-dependent drivers.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在内核配置指南中记录 RISC-V 特定的内核配置选项和设备支持。

文档：
- 在内核配置指南中描述 RISC-V CPU 选择、调试/DTrace/CTF 选项、`printf` 缓冲以及相关内核选项。
- 记录可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 特定的设备驱动程序。
- 记录 RISC-V 扁平设备树（flattened device tree）支持选项，并明确说明已禁用的传统兼容性、芯片组探测、声音（sound）、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document RISC-V-specific kernel configuration options and device support in the kernel configuration guide.

Documentation:
- Describe RISC-V CPU selection, debugging/DTrace/CTF options, printf buffering, and related kernel options in the kernel configuration guide.
- Document available RISC-V console, MMC/SD, UART, RTC, Ethernet, DMA, SPI, power management, and SiFive-specific device drivers.
- Record RISC-V flattened device tree support options and explicitly note disabled legacy compatibility, chipset probing, sound, hwpmc, and atomic-operation-dependent drivers.

</details>

文档更新内容：
- 增加对 RISC-V CPU 选择、调试、DTrace/CTF、`printf` 缓冲以及相关内核选项的说明。
- 描述可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 专用设备驱动程序。
- 记录 RISC-V 扁平化设备树（flattened device tree）支持选项，并明确注明已禁用的传统兼容性、芯片组探测、声音、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在内核配置指南中记录 RISC-V 特定的内核配置选项和设备支持。

文档：
- 在内核配置指南中描述 RISC-V CPU 选择、调试/DTrace/CTF 选项、`printf` 缓冲以及相关内核选项。
- 记录可用的 RISC-V 控制台、MMC/SD、UART、RTC、以太网、DMA、SPI、电源管理以及 SiFive 特定的设备驱动程序。
- 记录 RISC-V 扁平设备树（flattened device tree）支持选项，并明确说明已禁用的传统兼容性、芯片组探测、声音（sound）、`hwpmc` 以及依赖原子操作的驱动程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document RISC-V-specific kernel configuration options and device support in the kernel configuration guide.

Documentation:
- Describe RISC-V CPU selection, debugging/DTrace/CTF options, printf buffering, and related kernel options in the kernel configuration guide.
- Document available RISC-V console, MMC/SD, UART, RTC, Ethernet, DMA, SPI, power management, and SiFive-specific device drivers.
- Record RISC-V flattened device tree support options and explicitly note disabled legacy compatibility, chipset probing, sound, hwpmc, and atomic-operation-dependent drivers.

</details>

</details>

</details>

</details>