### PR TITLE
增补 PowerPC 机器相关内核配置与不支持选项文档

### DIFF
--- a/di-24-zhang-kernel/di-24.2-kernel-md.md
+++ b/di-24-zhang-kernel/di-24.2-kernel-md.md
@@ -1314,7 +1314,7 @@ NewWorld 系列 Apple PowerMac。
 #options         PS3
 ```
 
-Sony Playstation 3。
+Sony PlayStation 3。
 
 ```sh
 options         PSIM


### PR DESCRIPTION
## 由 Sourcery 提供的总结

为 FreeBSD 补充说明更多 PowerPC 内核配置选项，以及不受支持的设备/选项。

文档内容：
- 为 PowerPC 上与 DTrace 相关的内核选项和模块添加文档说明。
- 描述所需的 CPU 架构和 CPU 类型选项，包括各种模拟器和平台目标。
- 记录 `cpufreq` 支持情况、标准总线以及 Apple/PowerMac 特定设备，以及相关的传感器和控制器。
- 列出在 PowerPC 内核中应禁用或不受支持的内核设备和选项。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

为 FreeBSD 补充记录特定于 PowerPC 的内核配置选项以及不受支持的项目。

文档内容：
- 为 PowerPC 添加与 DTrace 相关的内核选项和模块文档。
- 描述所需的 PowerPC 机器、CPU 架构和 CPU 类型选项，包括仿真器和特定平台的目标配置。
- 记录 PowerPC 上的 cpufreq 支持、常见总线，以及 Apple/PowerMac 特定的设备、传感器和控制器。
- 列出在 PowerPC 内核中应禁用或不受支持的内核设备和选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional PowerPC-specific kernel configuration options and unsupported items for FreeBSD.

Documentation:
- Add DTrace-related kernel options and modules documentation for PowerPC.
- Describe required PowerPC machine, CPU architecture, and CPU type options, including emulator and platform-specific targets.
- Document cpufreq support, common buses, and Apple/PowerMac-specific devices, sensors, and controllers on PowerPC.
- List kernel devices and options that should be disabled or are unsupported on PowerPC kernels.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

为 FreeBSD 补充记录特定于 PowerPC 的内核配置选项以及不受支持的项目。

文档内容：
- 为 PowerPC 添加与 DTrace 相关的内核选项和模块文档。
- 描述所需的 PowerPC 机器、CPU 架构和 CPU 类型选项，包括仿真器和特定平台的目标配置。
- 记录 PowerPC 上的 cpufreq 支持、常见总线，以及 Apple/PowerMac 特定的设备、传感器和控制器。
- 列出在 PowerPC 内核中应禁用或不受支持的内核设备和选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional PowerPC-specific kernel configuration options and unsupported items for FreeBSD.

Documentation:
- Add DTrace-related kernel options and modules documentation for PowerPC.
- Describe required PowerPC machine, CPU architecture, and CPU type options, including emulator and platform-specific targets.
- Document cpufreq support, common buses, and Apple/PowerMac-specific devices, sensors, and controllers on PowerPC.
- List kernel devices and options that should be disabled or are unsupported on PowerPC kernels.

</details>

</details>

</details>