### PR TITLE
重构 KDE 安装文档：突出完整桌面并独立最小化附录

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.3-jie-an-zhuang-kde.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.3-jie-an-zhuang-kde.md
@@ -230,7 +230,7 @@ Current=sddm-freebsd-black-theme
 # cd /usr/ports/sysutils/plasma6-systemsettings/ && make install clean
 ```
 
-可选 Port：
+可选 Ports：
 
 ```
 # cd /usr/ports/x11/konsole/ && make install clean # 终端 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

重构 KDE 安装指南，将重点放在完整桌面安装流程上，同时将最小化安装步骤移入单独的附录部分。

增强内容：
- 将关于使用 startx 的小节提升为顶级章节，以改善在 KDE 设置指南中的导航清晰度。

文档更新：
- 明确主 KDE 安装章节为默认的完整桌面体验。
- 抽取并重组最小化 KDE 桌面安装说明，放入专门的附录中，并提供 pkg 和 Ports 示例、软件包表格以及截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重新聚焦 KDE 安装指南：以完整桌面安装为主，将最小化安装移至专门的附录，并改进与 `startx` 使用相关的导航结构。

Enhancements:
- 将 `startx` 使用小节提升为顶级章节，以提升其在 KDE 设置指南中的可发现性。

Documentation:
- 明确说明主 KDE 安装章节描述的是默认的完整桌面体验。
- 将最小化 KDE 桌面安装说明提取到独立的附录中，其中包括 pkg/Ports 示例、软件包表格和截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refocus the KDE installation guide on the full desktop installation while relegating the minimal setup to a dedicated appendix and improving navigation for startx usage.

Enhancements:
- Promote the startx usage subsection to a top-level section to improve discoverability in the KDE setup guide.

Documentation:
- Clarify that the main KDE installation section describes the default full desktop experience.
- Extract the minimal KDE desktop installation instructions into a standalone appendix, including pkg/Ports examples, package tables, and screenshots.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

重构 KDE 安装指南，将重点放在完整桌面安装流程上，同时将最小化安装步骤移入单独的附录部分。

增强内容：
- 将关于使用 startx 的小节提升为顶级章节，以改善在 KDE 设置指南中的导航清晰度。

文档更新：
- 明确主 KDE 安装章节为默认的完整桌面体验。
- 抽取并重组最小化 KDE 桌面安装说明，放入专门的附录中，并提供 pkg 和 Ports 示例、软件包表格以及截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重新聚焦 KDE 安装指南：以完整桌面安装为主，将最小化安装移至专门的附录，并改进与 `startx` 使用相关的导航结构。

Enhancements:
- 将 `startx` 使用小节提升为顶级章节，以提升其在 KDE 设置指南中的可发现性。

Documentation:
- 明确说明主 KDE 安装章节描述的是默认的完整桌面体验。
- 将最小化 KDE 桌面安装说明提取到独立的附录中，其中包括 pkg/Ports 示例、软件包表格和截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refocus the KDE installation guide on the full desktop installation while relegating the minimal setup to a dedicated appendix and improving navigation for startx usage.

Enhancements:
- Promote the startx usage subsection to a top-level section to improve discoverability in the KDE setup guide.

Documentation:
- Clarify that the main KDE installation section describes the default full desktop experience.
- Extract the minimal KDE desktop installation instructions into a standalone appendix, including pkg/Ports examples, package tables, and screenshots.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

重构 KDE 安装指南，将重点放在完整桌面安装流程上，同时将最小化安装步骤移入单独的附录部分。

增强内容：
- 将关于使用 startx 的小节提升为顶级章节，以改善在 KDE 设置指南中的导航清晰度。

文档更新：
- 明确主 KDE 安装章节为默认的完整桌面体验。
- 抽取并重组最小化 KDE 桌面安装说明，放入专门的附录中，并提供 pkg 和 Ports 示例、软件包表格以及截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重新聚焦 KDE 安装指南：以完整桌面安装为主，将最小化安装移至专门的附录，并改进与 `startx` 使用相关的导航结构。

Enhancements:
- 将 `startx` 使用小节提升为顶级章节，以提升其在 KDE 设置指南中的可发现性。

Documentation:
- 明确说明主 KDE 安装章节描述的是默认的完整桌面体验。
- 将最小化 KDE 桌面安装说明提取到独立的附录中，其中包括 pkg/Ports 示例、软件包表格和截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refocus the KDE installation guide on the full desktop installation while relegating the minimal setup to a dedicated appendix and improving navigation for startx usage.

Enhancements:
- Promote the startx usage subsection to a top-level section to improve discoverability in the KDE setup guide.

Documentation:
- Clarify that the main KDE installation section describes the default full desktop experience.
- Extract the minimal KDE desktop installation instructions into a standalone appendix, including pkg/Ports examples, package tables, and screenshots.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

重构 KDE 安装指南，将重点放在完整桌面安装流程上，同时将最小化安装步骤移入单独的附录部分。

增强内容：
- 将关于使用 startx 的小节提升为顶级章节，以改善在 KDE 设置指南中的导航清晰度。

文档更新：
- 明确主 KDE 安装章节为默认的完整桌面体验。
- 抽取并重组最小化 KDE 桌面安装说明，放入专门的附录中，并提供 pkg 和 Ports 示例、软件包表格以及截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重新聚焦 KDE 安装指南：以完整桌面安装为主，将最小化安装移至专门的附录，并改进与 `startx` 使用相关的导航结构。

Enhancements:
- 将 `startx` 使用小节提升为顶级章节，以提升其在 KDE 设置指南中的可发现性。

Documentation:
- 明确说明主 KDE 安装章节描述的是默认的完整桌面体验。
- 将最小化 KDE 桌面安装说明提取到独立的附录中，其中包括 pkg/Ports 示例、软件包表格和截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refocus the KDE installation guide on the full desktop installation while relegating the minimal setup to a dedicated appendix and improving navigation for startx usage.

Enhancements:
- Promote the startx usage subsection to a top-level section to improve discoverability in the KDE setup guide.

Documentation:
- Clarify that the main KDE installation section describes the default full desktop experience.
- Extract the minimal KDE desktop installation instructions into a standalone appendix, including pkg/Ports examples, package tables, and screenshots.

</details>

</details>

</details>

</details>