### PR TITLE
规范 KDE 安装文档中 startx 标题并独立 xinitrc 小节

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.3-jie-an-zhuang-kde.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.3-jie-an-zhuang-kde.md
@@ -48,7 +48,7 @@ KDE 旨在开发一套现代桌面系统，如果你觉得 KDE 界面很像 Wind
 
 ![KDE 6 界面](../.gitbook/assets/kde6-1.png)
 
-## `startx`
+## startx
 
 ```sh
 # echo "exec ck-launch-session startplasma-x11" > ~/.xinitrc
@@ -57,10 +57,6 @@ KDE 旨在开发一套现代桌面系统，如果你觉得 KDE 界面很像 Wind
 > **注意**
 >
 >如果你在 root 下已经执行过了，那么新用户仍要再执行一次才能正常使用（无需 root 权限或 sudo 等）`startx`。
-
->**注意**
->
->若采用最小化安装 KDE 方法，必须配置 `.xinitrc`！
 
 ## 权限设置
 
@@ -244,6 +240,12 @@ Current=sddm-freebsd-black-theme
 # cd /usr/ports/sysutils/plasma6-plasma-disks/ && make install clean # 磁盘健康（S.M.A.R.T.）监测 
 # cd /usr/ports/archivers/ark/ && make install clean # 解压缩软件 
 ```
+
+### xinitrc
+
+>**注意**
+>
+>若采用最小化安装 KDE 方法，必须配置 `.xinitrc`！
 
 ### 最小化安装 KDE 图示
 


### PR DESCRIPTION
## 由 Sourcery 提供的总结

在最小化安装环境中，围绕 startx 的使用以及 xinitrc 的配置，理清 KDE 安装文档的结构。

文档改动：
- 重命名 KDE 安装指南中有关 startx 的章节标题，以提高一致性和可读性。
- 将关于必须配置 `.xinitrc` 的说明移动并澄清，放入专门针对最小化 KDE 安装的 xinitrc 小节中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

文档：
- 规范 startx 章节标题的格式，并将关于在最小化 KDE 安装中必须配置 `.xinitrc` 的说明移动到一个专门的 xinitrc 小节中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Normalize the startx section heading formatting and relocate the note about mandatory .xinitrc configuration for minimal KDE installs into a dedicated xinitrc subsection.

</details>

</details>