### PR TITLE
删除句号

### DIFF
--- a/di-24-zhang-kernel/di-24.1-kernel-conf.md
+++ b/di-24-zhang-kernel/di-24.1-kernel-conf.md
@@ -2,8 +2,8 @@
 
 ## 内核配置选项路径
 
-- amd64 内核配置选项位于 [sys/amd64/conf](https://github.com/freebsd/freebsd-src/tree/main/sys/amd64/conf)。
-- Arm64 内核配置选项位于 [sys/arm64/conf](https://github.com/freebsd/freebsd-src/tree/main/sys/arm64/conf)。
+- amd64 内核配置选项位于 [sys/amd64/conf](https://github.com/freebsd/freebsd-src/tree/main/sys/amd64/conf)
+- Arm64 内核配置选项位于 [sys/arm64/conf](https://github.com/freebsd/freebsd-src/tree/main/sys/arm64/conf)
 - RISC-V 内核配置选项位于 [sys/riscv/conf](https://github.com/freebsd/freebsd-src/tree/main/sys/riscv/conf)
 
 ## 内核配置文件说明（基于 amd64）


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 移除 amd64 和 Arm64 内核配置路径列表项末尾的标点符号，以与文档风格保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Remove trailing punctuation from amd64 and Arm64 kernel configuration path list items to match documentation style.

</details>