### PR TITLE
重构 Hyprland 安装文档：补充警告与启动配置

### DIFF
--- a/di-7-zhang-chuang-kou/di-7.4-jie-an-zhuang-hyprland.md
+++ b/di-7-zhang-chuang-kou/di-7.4-jie-an-zhuang-hyprland.md
@@ -747,7 +747,7 @@ window#waybar {
 
 ## 配置 swaylock
 
-swaylock 的配置文件在 `~/.config/swaylock/config`
+swaylock 的配置文件在 `~/.config/swaylock/config` 中。
 
 - 示例配置文件：
 


### PR DESCRIPTION
## Sourcery 总结

通过更清晰的结构、启动配置说明以及排错指引，完善并扩展中文 Hyprland 安装指南。

文档更新：
- 增加醒目的警告，说明在常见虚拟机、Nvidia 显卡以及以 root 身份运行等不受支持的环境中可能出现的问题，并提供指向上游文档的链接以获取详情。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别介绍软件包的安装方式、各软件包的作用以及主配置文件的位置。
- 明确说明 `XDG_RUNTIME_DIR` 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，包括在无显示管理器的情况下，在不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点处理等行为差异。
- 改进针对启动失败和黑屏问题的排错指引，强调用户所属用户组、GPU 驱动和相关环境变量的重要性，并引用上游 Wiki 中的相关页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过更清晰的结构、启动配置说明以及排错指引，完善并扩展中文 Hyprland 安装指南。

文档更新：
- 增加醒目的警告，说明在常见虚拟机、Nvidia 显卡以及以 root 身份运行等不受支持的环境中可能出现的问题，并提供指向上游文档的链接以获取详情。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别介绍软件包的安装方式、各软件包的作用以及主配置文件的位置。
- 明确说明 `XDG_RUNTIME_DIR` 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，包括在无显示管理器的情况下，在不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点处理等行为差异。
- 改进针对启动失败和黑屏问题的排错指引，强调用户所属用户组、GPU 驱动和相关环境变量的重要性，并引用上游 Wiki 中的相关页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

</details>

</details>

</details>

文档更新内容：
- 添加显著的警告，说明不支持的环境，如常见虚拟机、Nvidia GPU 和以 root 身份运行，并附上上游文档的参考链接。
- 重构 Hyprland 安装章节，将安装方式、软件包说明，以及 Hyprland 和相关工具的配置文件位置拆分为更清晰的小节。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 来启动会话，同时提供针对不同 Shell 的自动启动配置指导。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置，并强调诸如焦点处理等关键行为差异。
- 改进针对启动失败和黑屏问题的故障排除指导，重点说明用户组成员关系、GPU 驱动和环境变量，并添加指向相关上游 Wiki 页面 的链接。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过更清晰的结构、启动配置说明以及排错指引，完善并扩展中文 Hyprland 安装指南。

文档更新：
- 增加醒目的警告，说明在常见虚拟机、Nvidia 显卡以及以 root 身份运行等不受支持的环境中可能出现的问题，并提供指向上游文档的链接以获取详情。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别介绍软件包的安装方式、各软件包的作用以及主配置文件的位置。
- 明确说明 `XDG_RUNTIME_DIR` 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，包括在无显示管理器的情况下，在不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点处理等行为差异。
- 改进针对启动失败和黑屏问题的排错指引，强调用户所属用户组、GPU 驱动和相关环境变量的重要性，并引用上游 Wiki 中的相关页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过更清晰的结构、启动配置说明以及排错指引，完善并扩展中文 Hyprland 安装指南。

文档更新：
- 增加醒目的警告，说明在常见虚拟机、Nvidia 显卡以及以 root 身份运行等不受支持的环境中可能出现的问题，并提供指向上游文档的链接以获取详情。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别介绍软件包的安装方式、各软件包的作用以及主配置文件的位置。
- 明确说明 `XDG_RUNTIME_DIR` 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，包括在无显示管理器的情况下，在不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点处理等行为差异。
- 改进针对启动失败和黑屏问题的排错指引，强调用户所属用户组、GPU 驱动和相关环境变量的重要性，并引用上游 Wiki 中的相关页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

</details>

</details>

</details>

</details>

文档更新：
- 增加关于不受支持环境的明确警告（虚拟机、Nvidia、以 root 身份使用），并链接到上游文档以说明原因。
- 使用小标题对安装和配置章节进行重构，解释相关软件包，并提供更清晰的 `XDG_RUNTIME_DIR` 和自动启动配置示例。
- 推荐使用 `dbus-run-session Hyprland` 来启动会话，并明确 hyprland.conf、kitty、waybar 和 swaylock 的配置位置及示例片段。
- 改进启动失败和黑屏问题的故障排除指南，重点强调用户组成员资格、GPU 驱动以及环境变量等因素。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过更清晰的结构、启动配置说明以及排错指引，完善并扩展中文 Hyprland 安装指南。

文档更新：
- 增加醒目的警告，说明在常见虚拟机、Nvidia 显卡以及以 root 身份运行等不受支持的环境中可能出现的问题，并提供指向上游文档的链接以获取详情。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别介绍软件包的安装方式、各软件包的作用以及主配置文件的位置。
- 明确说明 `XDG_RUNTIME_DIR` 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，包括在无显示管理器的情况下，在不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点处理等行为差异。
- 改进针对启动失败和黑屏问题的排错指引，强调用户所属用户组、GPU 驱动和相关环境变量的重要性，并引用上游 Wiki 中的相关页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过更清晰的结构、启动配置说明以及排错指引，完善并扩展中文 Hyprland 安装指南。

文档更新：
- 增加醒目的警告，说明在常见虚拟机、Nvidia 显卡以及以 root 身份运行等不受支持的环境中可能出现的问题，并提供指向上游文档的链接以获取详情。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别介绍软件包的安装方式、各软件包的作用以及主配置文件的位置。
- 明确说明 `XDG_RUNTIME_DIR` 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，包括在无显示管理器的情况下，在不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点处理等行为差异。
- 改进针对启动失败和黑屏问题的排错指引，强调用户所属用户组、GPU 驱动和相关环境变量的重要性，并引用上游 Wiki 中的相关页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

</details>

</details>

</details>

文档更新内容：
- 添加显著的警告，说明不支持的环境，如常见虚拟机、Nvidia GPU 和以 root 身份运行，并附上上游文档的参考链接。
- 重构 Hyprland 安装章节，将安装方式、软件包说明，以及 Hyprland 和相关工具的配置文件位置拆分为更清晰的小节。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 来启动会话，同时提供针对不同 Shell 的自动启动配置指导。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置，并强调诸如焦点处理等关键行为差异。
- 改进针对启动失败和黑屏问题的故障排除指导，重点说明用户组成员关系、GPU 驱动和环境变量，并添加指向相关上游 Wiki 页面 的链接。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过更清晰的结构、启动配置说明以及排错指引，完善并扩展中文 Hyprland 安装指南。

文档更新：
- 增加醒目的警告，说明在常见虚拟机、Nvidia 显卡以及以 root 身份运行等不受支持的环境中可能出现的问题，并提供指向上游文档的链接以获取详情。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别介绍软件包的安装方式、各软件包的作用以及主配置文件的位置。
- 明确说明 `XDG_RUNTIME_DIR` 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，包括在无显示管理器的情况下，在不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点处理等行为差异。
- 改进针对启动失败和黑屏问题的排错指引，强调用户所属用户组、GPU 驱动和相关环境变量的重要性，并引用上游 Wiki 中的相关页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过更清晰的结构、启动配置说明以及排错指引，完善并扩展中文 Hyprland 安装指南。

文档更新：
- 增加醒目的警告，说明在常见虚拟机、Nvidia 显卡以及以 root 身份运行等不受支持的环境中可能出现的问题，并提供指向上游文档的链接以获取详情。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别介绍软件包的安装方式、各软件包的作用以及主配置文件的位置。
- 明确说明 `XDG_RUNTIME_DIR` 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，包括在无显示管理器的情况下，在不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点处理等行为差异。
- 改进针对启动失败和黑屏问题的排错指引，强调用户所属用户组、GPU 驱动和相关环境变量的重要性，并引用上游 Wiki 中的相关页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

文档更新内容：
- 增加醒目的警告，说明不支持的运行环境，例如常见虚拟机、Nvidia GPU 和 root 用户使用，并附上上游文档链接。
- 重构 Hyprland 安装章节，将其拆分为更清晰的小节，分别说明软件包安装方式、各软件包的角色以及配置文件的存放位置。
- 记录正确的 `XDG_RUNTIME_DIR` 设置方式，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时说明在不同登录 shell 下的注意事项，以及在无显示管理器情况下的自动启动配置方法。
- 明确配置文件所在位置，并为 `hyprland.conf`、kitty、waybar 和 swaylock 提供示例配置片段，包括诸如焦点处理等行为差异说明。
- 加强针对启动失败和黑屏问题的故障排除指引，突出用户所属用户组、GPU 驱动和环境变量的重要性，并链接到相关的上游 Wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

细化并扩展中文 Hyprland 安装指南，使其在结构、启动配置和故障排查方面更加清晰。

文档更新：
- 新增醒目的警告，说明不支持的环境（常见虚拟机、Nvidia 显卡、root 身份使用），并附上上游文档链接以获取详情。
- 重构 Hyprland 安装章节，将其划分为更清晰的小节，涵盖 pkg/Ports 安装、各软件包的作用以及关键配置文件的位置。
- 明确说明 XDG_RUNTIME_DIR 的设置，并推荐使用 `dbus-run-session Hyprland` 启动会话，同时给出在没有显示管理器情况下，不同 Shell 中实现自动启动的示例。
- 记录 hyprland.conf、kitty、waybar 和 swaylock 的示例配置及路径，并强调诸如焦点行为等差异。
- 加强对启动失败、黑屏等问题的排障指导，强调用户组成员资格、GPU 驱动和环境变量的重要性，并引用相关的上游 wiki 页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and expand the Chinese Hyprland installation guide with clearer structure, startup configuration, and troubleshooting notes.

Documentation:
- Add prominent warnings about unsupported environments (common virtual machines, Nvidia GPUs, root usage) with links to upstream documentation for details.
- Restructure the Hyprland installation chapter into clearer subsections covering pkg/Ports installation, package roles, and key configuration file locations.
- Clarify XDG_RUNTIME_DIR setup and recommend starting sessions with `dbus-run-session Hyprland`, including examples for automatic startup without a display manager across different shells.
- Document example configurations and paths for hyprland.conf, kitty, waybar, and swaylock, and highlight behavioral differences such as focus handling.
- Enhance troubleshooting guidance for startup failures and black screens by emphasizing user group membership, GPU drivers, and environment variables, and by referencing relevant upstream wiki pages.

</details>

</details>

</details>

</details>

</details>

</details>

</details>