### PR TITLE
更新 CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ## 2025 年第四季度
 
+- 2025.128.
+  - “5.1 FreeBSD 镜像站现状”新增“拒绝开放的可能性原因分析”
 - 2025.12.7
   - 完全重写：“25.5 更新 ZFS 的 zpool”
-  - “5.1 FreeBSD 镜像站现状”增补“拒绝开放的可能性原因分析”
   - 完全重写：“5.7 使用 freebsd-update 更新 FreeBSD”。注：在使用 freebsd-update 从 14.3 或更低版本进行更新时，必须先更新到最新的补丁版本再进行大版本间的更迭。否则会挂。方法：`freebsd-update fetch && freebsd-update install` 参见 <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289769> 和 <https://www.freebsd.org/releases/15.0R/installation/#upgrade-binary>
 - 2025.12.6
   - 将“5.9 使用 pkgbase 更新 FreeBSD”完全重写为“5.9 使用 ZFS 启动环境更新 FreeBSD 并实现多版本共存”


### PR DESCRIPTION
## Summary by Sourcery

更新 2025 年第 4 季度的变更日志条目，以反映最新的文档更改，并更正 FreeBSD 镜像分析备注的日期关联。

文档：
- 记录新的 2025.12.8 条目，描述新增的关于拒绝开放 FreeBSD 镜像的可能原因分析。
- 调整 2025.12.7 的变更日志条目，将 FreeBSD 镜像分析备注移动到新的 2025.12.8 日期下。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the changelog entries for 2025 Q4 to reflect the latest documentation changes and correct the date association for the FreeBSD mirror analysis note.

Documentation:
- Document a new 2025.12.8 entry describing the added analysis of possible reasons for refusing to open the FreeBSD mirror.
- Adjust the 2025.12.7 changelog entry so the FreeBSD mirror analysis note is now recorded under the new 2025.12.8 date.

</details>