### PR TITLE
扩展 mihomo RC 脚本文档并修订最小配置示例

### DIFF
--- a/di-10-zhang-vpn-yu-dai-li/di-10.3-jie-clash.md
+++ b/di-10-zhang-vpn-yu-dai-li/di-10.3-jie-clash.md
@@ -131,7 +131,7 @@ sysrc mihomo_geoip="https://ghfast.top/https://github.com/MetaCubeX/meta-rules-d
 - 指定其他 mihomo 参数
 
 ```sh
-sysrc mihomo_extra_flags="-m" # 可选。但建议
+sysrc mihomo_extra_flags="-m" # 可选，但建议使用
 ```
 
 - `-m`：指定 mihomo geoip.dat 配置文件的路径。具体见 rc 脚本。


### PR DESCRIPTION
## Summary by Sourcery

更新 mihomo RC 脚本文档，以更好地指导用户在 FreeBSD 上完成安装、配置和最小化设置。

文档内容：
- 说明如何在 `/usr/local/etc/rc.d/` 下创建、安装并赋予 mihomo RC 脚本可执行权限。
- 澄清 `sysrc` 会将设置写入 `/etc/rc.conf`，并建议通过直接编辑该文件来修正配置错误。
- 优化对 mihomo 配置选项的说明，包括 `geoip`、额外参数（extra flags）、`user` 和 `datadir`，并提供更清晰的注释和使用说明。
- 修改最小 RC 配置示例，使用正确的值（例如 `YES`），并添加更具指导性的注释，以便实现可正常工作的基础配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the mihomo RC script documentation to better guide users through installation, configuration, and minimal setup on FreeBSD.

Documentation:
- Document how to create, install, and make the mihomo RC script executable under /usr/local/etc/rc.d/.
- Clarify that sysrc writes settings into /etc/rc.conf and suggest fixing mistakes by editing that file directly.
- Refine explanations of mihomo configuration options, including geoip, extra flags, user, and datadir, with clearer comments and usage notes.
- Revise the minimal RC configuration example to use correct values (e.g., YES) and more instructive annotations for a working basic setup.

</details>

文档更新内容：
- 说明如何创建、安装 mihomo RC 脚本并赋予其可执行权限。
- 解释 `sysrc` 会写入 `/etc/rc.conf`，并建议通过直接编辑该文件来修正配置错误。
- 改进对 mihomo 配置选项的说明和注释，包括 `geoip`、额外参数（extra flags）、运行用户（user）以及数据目录（datadir）。
- 修订最小化的 RC 配置示例，使其使用正确的参数值，并提供更准确且具有指导性的注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 mihomo RC 脚本文档，以更好地指导用户在 FreeBSD 上完成安装、配置和最小化设置。

文档内容：
- 说明如何在 `/usr/local/etc/rc.d/` 下创建、安装并赋予 mihomo RC 脚本可执行权限。
- 澄清 `sysrc` 会将设置写入 `/etc/rc.conf`，并建议通过直接编辑该文件来修正配置错误。
- 优化对 mihomo 配置选项的说明，包括 `geoip`、额外参数（extra flags）、`user` 和 `datadir`，并提供更清晰的注释和使用说明。
- 修改最小 RC 配置示例，使用正确的值（例如 `YES`），并添加更具指导性的注释，以便实现可正常工作的基础配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the mihomo RC script documentation to better guide users through installation, configuration, and minimal setup on FreeBSD.

Documentation:
- Document how to create, install, and make the mihomo RC script executable under /usr/local/etc/rc.d/.
- Clarify that sysrc writes settings into /etc/rc.conf and suggest fixing mistakes by editing that file directly.
- Refine explanations of mihomo configuration options, including geoip, extra flags, user, and datadir, with clearer comments and usage notes.
- Revise the minimal RC configuration example to use correct values (e.g., YES) and more instructive annotations for a working basic setup.

</details>

</details>

文档更新内容：
- 新增安装 mihomo RC 脚本并设置可执行权限的步骤说明。
- 说明 `sysrc` 命令会写入 `/etc/rc.conf`，并指出如有错误可通过编辑该文件进行修正。
- 优化 mihomo 配置选项（包括 `geoip`、额外参数（extra flags）、`user` 和 `datadir` 设置）的描述和注释。
- 更新最小化 RC 配置示例，使其更为准确、指导更清晰，包括使用正确的 `YES` 值以及补充说明性注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 mihomo RC 脚本文档，以更好地指导用户在 FreeBSD 上完成安装、配置和最小化设置。

文档内容：
- 说明如何在 `/usr/local/etc/rc.d/` 下创建、安装并赋予 mihomo RC 脚本可执行权限。
- 澄清 `sysrc` 会将设置写入 `/etc/rc.conf`，并建议通过直接编辑该文件来修正配置错误。
- 优化对 mihomo 配置选项的说明，包括 `geoip`、额外参数（extra flags）、`user` 和 `datadir`，并提供更清晰的注释和使用说明。
- 修改最小 RC 配置示例，使用正确的值（例如 `YES`），并添加更具指导性的注释，以便实现可正常工作的基础配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the mihomo RC script documentation to better guide users through installation, configuration, and minimal setup on FreeBSD.

Documentation:
- Document how to create, install, and make the mihomo RC script executable under /usr/local/etc/rc.d/.
- Clarify that sysrc writes settings into /etc/rc.conf and suggest fixing mistakes by editing that file directly.
- Refine explanations of mihomo configuration options, including geoip, extra flags, user, and datadir, with clearer comments and usage notes.
- Revise the minimal RC configuration example to use correct values (e.g., YES) and more instructive annotations for a working basic setup.

</details>

文档更新内容：
- 说明如何创建、安装 mihomo RC 脚本并赋予其可执行权限。
- 解释 `sysrc` 会写入 `/etc/rc.conf`，并建议通过直接编辑该文件来修正配置错误。
- 改进对 mihomo 配置选项的说明和注释，包括 `geoip`、额外参数（extra flags）、运行用户（user）以及数据目录（datadir）。
- 修订最小化的 RC 配置示例，使其使用正确的参数值，并提供更准确且具有指导性的注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 mihomo RC 脚本文档，以更好地指导用户在 FreeBSD 上完成安装、配置和最小化设置。

文档内容：
- 说明如何在 `/usr/local/etc/rc.d/` 下创建、安装并赋予 mihomo RC 脚本可执行权限。
- 澄清 `sysrc` 会将设置写入 `/etc/rc.conf`，并建议通过直接编辑该文件来修正配置错误。
- 优化对 mihomo 配置选项的说明，包括 `geoip`、额外参数（extra flags）、`user` 和 `datadir`，并提供更清晰的注释和使用说明。
- 修改最小 RC 配置示例，使用正确的值（例如 `YES`），并添加更具指导性的注释，以便实现可正常工作的基础配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the mihomo RC script documentation to better guide users through installation, configuration, and minimal setup on FreeBSD.

Documentation:
- Document how to create, install, and make the mihomo RC script executable under /usr/local/etc/rc.d/.
- Clarify that sysrc writes settings into /etc/rc.conf and suggest fixing mistakes by editing that file directly.
- Refine explanations of mihomo configuration options, including geoip, extra flags, user, and datadir, with clearer comments and usage notes.
- Revise the minimal RC configuration example to use correct values (e.g., YES) and more instructive annotations for a working basic setup.

</details>

</details>

</details>