### PR TITLE
补遗

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.11-jie-an-zhuang-cde.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.11-jie-an-zhuang-cde.md
@@ -147,13 +147,15 @@ dtspc		6112/tcp
 
 ## 故障排除与未竟事宜
 
-- 无法中文化（似乎日历是中文）
+### 无法设置中文环境
 
-待解决
+（似乎日历是中文）
+
+根据源码 <https://sourceforge.net/p/cdesktopenv/code/ci/master/tree/cde/imports/motif/localized/>，不存在中文支持。但是根据 [简体中文 Solaris 用户指南](https://docs.oracle.com/cd/E19683-01/816-0668/6m7500nqp/index.html)，其明显存在简体中文支持，疑似在开源中弄丢了，或者 Solaris 是个分支未合并。已经反馈至 [Missing Simplified Chinese locale support under cde/imports/motif/localized](https://sourceforge.net/p/cdesktopenv/discussion/general/thread/c51abcd846/)。
 
 
 ## 参考文献
 
-- [cde Common Desktop Environment](https://www.freshports.org/x11/cde)
+- [cde Common Desktop Environment](https://www.freshports.org/x11/cde)，Ports 详情
 - [Setting up Common Desktop Environment for modern use](https://forums.freebsd.org/threads/setting-up-common-desktop-environment-for-modern-use.69475/)，详细配置可参考此处
 - [CDE - Common Desktop Environment Wiki](https://sourceforge.net/p/cdesktopenv/wiki/FreeBSDBuild/)，CDE 项目官方 WiKi


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

澄清有关 CDE 中缺少中文语言环境（locale）支持的故障排除部分，并在引用中补充有关 FreeBSD ports 条目的额外背景信息。

文档：
- 记录开源 CDE 代码库中缺少简体中文语言环境支持的情况，并引用相关的源代码、历史 Solaris 文档以及上游讨论线程。
- 澄清 FreeBSD CDE ports 文档链接的说明，表明其提供了详细的 Ports 信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the troubleshooting section about missing Chinese locale support in CDE and update references with additional context about the FreeBSD ports entry.

Documentation:
- Document the lack of Simplified Chinese locale support in the open-source CDE tree, referencing relevant source code, historical Solaris documentation, and an upstream discussion thread.
- Clarify the FreeBSD CDE ports documentation link as providing detailed Ports information.

</details>