### PR TITLE
重构 create-pdf 工作流的标签与发布流程

### DIFF
--- a/.github/workflows/create-pdf.yml
+++ b/.github/workflows/create-pdf.yml
@@ -62,7 +62,15 @@ jobs:
             libpangoft2-1.0-0 \
             libpangocairo-1.0-0
           pip install weasyprint mistune pygments EbookLib beautifulsoup4
-
+      # ================= PDF 生成部分 =================
+      - name: 生成 PDF 文档
+        run: |
+          cd pdf-generator
+          python mdconv.py ../FreeBSD-Ask
+          mv build/final.pdf build/$(date +'%Y.%m.%d').pdf
+          mv build/final.epub build/$(date +'%Y.%m.%d').epub
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pdf-generator
       # ================= 发布流程部分 =================
       - name: 🚀 设置发布日期标签
         id: set_tag


### PR DESCRIPTION
## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

CI：
- 确保发布日期标签只设置一次，在各个工作流步骤中复用，并且只在该标签尚不存在时才创建并推送。
- 更改“上一标签”的检测逻辑为使用“按创建时间排序的次新标签”，并在标签数量少于两个时进行友好处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该内容直接作为发布说明（release body）传递。
- 切换为使用 `softprops/action-gh-release` 来创建或更新包含 PDF/EPUB 工件的发布，将其标记为最新（latest）并启用覆盖（overwrite）。
- 从工作流中移除不必要的诊断命令以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

</details>

增强点：
- 确保仅在缺少发布标签时才创建标签，并在工作流各步骤中复用该标签。
- 将上一个标签的检测方式改为使用“最近创建的第二个标签”，并在标签少于两个时进行优雅处理。
- 用单个变更日志构建 Action 替换之前的变更日志生成和独立的发布更新步骤，并将其输出直接作为 Release 的正文内容。
- 采用 softprops/action-gh-release 来创建或更新包含 PDF/EPUB 制品的 Release，同时简化相关配置，并从工作流中移除噪声较大的诊断命令。

CI：
- 重构 create-pdf GitHub Actions 工作流，以集中管理发布标签处理，并简化 Release 创建流水线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

CI：
- 确保发布日期标签只设置一次，在各个工作流步骤中复用，并且只在该标签尚不存在时才创建并推送。
- 更改“上一标签”的检测逻辑为使用“按创建时间排序的次新标签”，并在标签数量少于两个时进行友好处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该内容直接作为发布说明（release body）传递。
- 切换为使用 `softprops/action-gh-release` 来创建或更新包含 PDF/EPUB 工件的发布，将其标记为最新（latest）并启用覆盖（overwrite）。
- 从工作流中移除不必要的诊断命令以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

</details>

</details>

CI：
- 在各个工作流程步骤中复用单一的基于日期的发布标签，并将其推送为新的 Git 标签。
- 将之前的标签检测逻辑改为按创建时间使用“次新”标签；当标签少于两个时能优雅降级处理。
- 用一个 changelog-builder 动作替换现有的变更日志生成器和单独的发布更新步骤，并将其输出直接作为发布说明内容。
- 切换为使用 `softprops/action-gh-release` 来创建或更新带有 PDF/EPUB 工件的发布，并简化相关配置。
- 从 CI 步骤中移除不必要的诊断命令，以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

CI：
- 确保发布日期标签只设置一次，在各个工作流步骤中复用，并且只在该标签尚不存在时才创建并推送。
- 更改“上一标签”的检测逻辑为使用“按创建时间排序的次新标签”，并在标签数量少于两个时进行友好处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该内容直接作为发布说明（release body）传递。
- 切换为使用 `softprops/action-gh-release` 来创建或更新包含 PDF/EPUB 工件的发布，将其标记为最新（latest）并启用覆盖（overwrite）。
- 从工作流中移除不必要的诊断命令以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

</details>

增强点：
- 确保仅在缺少发布标签时才创建标签，并在工作流各步骤中复用该标签。
- 将上一个标签的检测方式改为使用“最近创建的第二个标签”，并在标签少于两个时进行优雅处理。
- 用单个变更日志构建 Action 替换之前的变更日志生成和独立的发布更新步骤，并将其输出直接作为 Release 的正文内容。
- 采用 softprops/action-gh-release 来创建或更新包含 PDF/EPUB 制品的 Release，同时简化相关配置，并从工作流中移除噪声较大的诊断命令。

CI：
- 重构 create-pdf GitHub Actions 工作流，以集中管理发布标签处理，并简化 Release 创建流水线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

CI：
- 确保发布日期标签只设置一次，在各个工作流步骤中复用，并且只在该标签尚不存在时才创建并推送。
- 更改“上一标签”的检测逻辑为使用“按创建时间排序的次新标签”，并在标签数量少于两个时进行友好处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该内容直接作为发布说明（release body）传递。
- 切换为使用 `softprops/action-gh-release` 来创建或更新包含 PDF/EPUB 工件的发布，将其标记为最新（latest）并启用覆盖（overwrite）。
- 从工作流中移除不必要的诊断命令以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

</details>

</details>

</details>

CI：
- 仅设置一次发布标签，并在 create-pdf 工作流的后续步骤中复用该标签。
- 更改之前的标签解析方式，使用“倒数第二个创建的标签”来替代“最新标签描述符”。
- 简化发布创建流程，在上传步骤中直接将生成的变更日志作为发布正文传入，并移除单独的发布更新步骤。
- 从工作流步骤中移除不必要的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

CI：
- 确保发布日期标签只设置一次，在各个工作流步骤中复用，并且只在该标签尚不存在时才创建并推送。
- 更改“上一标签”的检测逻辑为使用“按创建时间排序的次新标签”，并在标签数量少于两个时进行友好处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该内容直接作为发布说明（release body）传递。
- 切换为使用 `softprops/action-gh-release` 来创建或更新包含 PDF/EPUB 工件的发布，将其标记为最新（latest）并启用覆盖（overwrite）。
- 从工作流中移除不必要的诊断命令以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

</details>

增强点：
- 确保仅在缺少发布标签时才创建标签，并在工作流各步骤中复用该标签。
- 将上一个标签的检测方式改为使用“最近创建的第二个标签”，并在标签少于两个时进行优雅处理。
- 用单个变更日志构建 Action 替换之前的变更日志生成和独立的发布更新步骤，并将其输出直接作为 Release 的正文内容。
- 采用 softprops/action-gh-release 来创建或更新包含 PDF/EPUB 制品的 Release，同时简化相关配置，并从工作流中移除噪声较大的诊断命令。

CI：
- 重构 create-pdf GitHub Actions 工作流，以集中管理发布标签处理，并简化 Release 创建流水线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

CI：
- 确保发布日期标签只设置一次，在各个工作流步骤中复用，并且只在该标签尚不存在时才创建并推送。
- 更改“上一标签”的检测逻辑为使用“按创建时间排序的次新标签”，并在标签数量少于两个时进行友好处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该内容直接作为发布说明（release body）传递。
- 切换为使用 `softprops/action-gh-release` 来创建或更新包含 PDF/EPUB 工件的发布，将其标记为最新（latest）并启用覆盖（overwrite）。
- 从工作流中移除不必要的诊断命令以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

</details>

</details>

CI：
- 在各个工作流程步骤中复用单一的基于日期的发布标签，并将其推送为新的 Git 标签。
- 将之前的标签检测逻辑改为按创建时间使用“次新”标签；当标签少于两个时能优雅降级处理。
- 用一个 changelog-builder 动作替换现有的变更日志生成器和单独的发布更新步骤，并将其输出直接作为发布说明内容。
- 切换为使用 `softprops/action-gh-release` 来创建或更新带有 PDF/EPUB 工件的发布，并简化相关配置。
- 从 CI 步骤中移除不必要的诊断命令，以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

CI：
- 确保发布日期标签只设置一次，在各个工作流步骤中复用，并且只在该标签尚不存在时才创建并推送。
- 更改“上一标签”的检测逻辑为使用“按创建时间排序的次新标签”，并在标签数量少于两个时进行友好处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该内容直接作为发布说明（release body）传递。
- 切换为使用 `softprops/action-gh-release` 来创建或更新包含 PDF/EPUB 工件的发布，将其标记为最新（latest）并启用覆盖（overwrite）。
- 从工作流中移除不必要的诊断命令以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

</details>

增强点：
- 确保仅在缺少发布标签时才创建标签，并在工作流各步骤中复用该标签。
- 将上一个标签的检测方式改为使用“最近创建的第二个标签”，并在标签少于两个时进行优雅处理。
- 用单个变更日志构建 Action 替换之前的变更日志生成和独立的发布更新步骤，并将其输出直接作为 Release 的正文内容。
- 采用 softprops/action-gh-release 来创建或更新包含 PDF/EPUB 制品的 Release，同时简化相关配置，并从工作流中移除噪声较大的诊断命令。

CI：
- 重构 create-pdf GitHub Actions 工作流，以集中管理发布标签处理，并简化 Release 创建流水线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

CI：
- 确保发布日期标签只设置一次，在各个工作流步骤中复用，并且只在该标签尚不存在时才创建并推送。
- 更改“上一标签”的检测逻辑为使用“按创建时间排序的次新标签”，并在标签数量少于两个时进行友好处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该内容直接作为发布说明（release body）传递。
- 切换为使用 `softprops/action-gh-release` 来创建或更新包含 PDF/EPUB 工件的发布，将其标记为最新（latest）并启用覆盖（overwrite）。
- 从工作流中移除不必要的诊断命令以减少噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

CI：
- 在整个工作流步骤中复用单个基于日期的发布标签，仅在该标签尚不存在时创建并推送。
- 将上一个标签的检测方式改为使用最近创建的第二个标签，并在少于两个标签存在时进行平滑处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传递。
- 切换为使用 `softprops/action-gh-release`，在启用覆盖的情况下，将 PDF/EPUB 发布创建或更新为最新发布，并简化配置。
- 从工作流中移除多余的诊断命令，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 `create-pdf` GitHub Actions 工作流，使发布打标签和变更日志生成更安全，并简化 PDF/EPUB 制品的发布流程。

CI：
- 确保基于日期的发布标签只设置一次，在工作流步骤之间复用，并且仅在该标签尚不存在时才创建并推送。
- 更改“前一个标签”的解析方式，改为使用「倒数第二个创建的标签」，并在标签少于两个时进行优雅处理。
- 用基于 `git log` 的内联变更日志替换现有的变更日志生成器和单独的发布更新步骤，并将该变更日志直接作为发布正文传入。
- 切换为使用 `softprops/action-gh-release` 来创建或更新 PDF/EPUB 发布，将其标记为最新发布并启用覆盖功能，同时简化配置并移除冗余的诊断命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the create-pdf GitHub Actions workflow to make release tagging and changelog generation safer and to streamline release creation for PDF/EPUB artifacts.

CI:
- Ensure the date-based release tag is set once, reused across workflow steps, and only created and pushed when it does not already exist.
- Change previous-tag resolution to use the second most recently created tag with graceful handling when fewer than two tags exist.
- Replace the existing changelog generator and separate release-update step with an inline git-log-based changelog that is passed directly as the release body.
- Switch to softprops/action-gh-release to create or update the PDF/EPUB release as the latest release with overwrite enabled, while simplifying configuration and removing noisy diagnostic commands.

</details>

</details>

</details>

</details>

</details>

</details>