### PR TITLE
补遗

### DIFF
--- a/di-25-zhang-zfs/di-25.1-zfs-gaishu.md
+++ b/di-25-zhang-zfs/di-25.1-zfs-gaishu.md
@@ -9,13 +9,15 @@ ZFS 于 2005 年 11 月 1 日（revision 789）以 CDDL（Common Development and
 
 在 2007 年，ZFS 在 FreeBSD 7.0（pool v6）中以实验状态正式发布，在 FreeBSD 8.0（2009 年, pool v13）中宣布为生产就绪状态。
 
-2009 年 4 月 Oracle 收购 SUN 之后，Solaris 项目（易名为 Oracle Solaris）及 ZFS（易名为 Oracle Solaris ZFS）进入闭源开发模式，OpenSolaris 社区管理委员会于 2010 年 8 月自行解散（revision 13149, pool v28）。OpenSolaris 的主要社区开发力量迁移到了新分支 [illumos 项目](https://github.com/illumos/illumos-gate) 中。从此以后，Oracle Solaris ZFS 与社区版本开始分支。
+2009 年 4 月 Oracle 收购 SUN 之后，Solaris 项目（易名为 Oracle Solaris）及 ZFS（易名为 Oracle Solaris ZFS）进入闭源开发模式，OpenSolaris 社区管理委员会于 2010 年 8 月自行解散（revision 13149，在解散时 ZFS pool 为 [v28](https://github.com/freebsd/freebsd-src/commit/572e285762521df27fe5b026f409ba1a21abb7ac)）。OpenSolaris 的主要社区开发力量迁移到了新分支 [illumos 项目](https://github.com/illumos/illumos-gate) 中。从此以后（v28），Oracle Solaris ZFS 与社区版本开始分支。
 
 目前 illumos 类似 Linux Kernel 的开发模式，衍生出了 OpenIndiana、OmniOS 等十余款发行版。但从实际的代码提交量来看（年平均代码提交次数在 150 上下），illumos 的开发一蹶不振，直到如今仍未走出阴影。
 
-2011 年 2 月，FreeBSD 采用了 ZFS pool v15，这是 2009 年 10 月随 Solaris 10 update 8 分发的版本。
+2011 年 2 月，FreeBSD 采用了 ZFS pool v15，这是 2009 年 10 月随 Solaris 10 update 8（Solaris 10 10/09）分发的版本。
 
 2011 年 11 月，Oracle Solaris 11 发布。ZFS pool v31。
+
+2012 年 1 月 12 日，FreeBSD 9.0-RELEASE 支持了 ZFS pool v28。参见：[Finally... Import the latest open-source ZFS version - (SPA) 28.](https://github.com/freebsd/freebsd-src/commit/10b9d77bf1ccf2f3affafa6261692cb92cf7e992)。
 
 在 OpenSolaris 关停 3 年后（2013），ZFS 的主要开发者迁移到了 ZFSonLinux，后重命名成为如今的 OpenZFS。OpenZFS 旨在统一 ZFS 的开源开发（此前还有若干类似移植到 Linux 目的的项目）。由于 Oracle Solaris ZFS 的闭源开发，OpenZFS 很难再兼容 Oracle Solaris ZFS。
 


### PR DESCRIPTION
## 由 Sourcery 提供的总结

澄清并丰富 ZFS 及其分支的历史时间线，特别是围绕 OpenSolaris 停摆以及 FreeBSD 采用 ZFS 存储池版本的相关内容。

文档：
- 为 OpenSolaris 委员会解散时期的 ZFS 存储池 v28 以及 FreeBSD 9.0-RELEASE 对其支持，补充精确的参考资料和链接。
- 在历史描述中，澄清 Solaris 10 update 8 的命名方式及其与 ZFS 存储池 v15 之间的关系。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and enrich the historical timeline of ZFS and its forks, especially around the OpenSolaris shutdown and FreeBSD ZFS pool version adoption.

Documentation:
- Add precise references and links for ZFS pool v28 at the time of the OpenSolaris committee dissolution and FreeBSD 9.0-RELEASE support.
- Clarify Solaris 10 update 8 naming and its relation to ZFS pool v15 in the historical description.

</details>