### PR TITLE
测试 nginx 代码高亮

### DIFF
--- a/di-17-zhang-wang-luo-fu-wu-qi/di-17.2-jie-nginx.md
+++ b/di-17-zhang-wang-luo-fu-wu-qi/di-17.2-jie-nginx.md
@@ -72,7 +72,7 @@ root     nginx       1153 6   tcp4   *:80                  *:*
 
 默认配置中，Nginx 的站点根目录为 `/usr/local/www/nginx/`。如需更改站点根目录，请在 `/usr/local/etc/nginx/nginx.conf` 中将
 
-```ini
+```nginx
 root	/usr/local/www/nginx;
 ```
 
@@ -80,7 +80,7 @@ root	/usr/local/www/nginx;
 
 ### 示例配置文件（Nginx + Typecho 伪静态 + SSL）
 
-```ini
+```nginx
 #user  nobody;                                   # 指定 Nginx 运行用户，默认注释表示使用编译时设置
 worker_processes  1;                             # 工作进程数量
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 将 Nginx 配置的代码块语言标记从 `ini` 更改为 `nginx`，以在指南中启用正确的语法高亮显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Change Nginx configuration code fences from ini to nginx to enable proper syntax highlighting in the guide.

</details>