### PR TITLE
typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,7 @@
 ## 2025 年第二季度
 
 - 2025.6.24
-  - freebsd 14.3 的 wifi county select 有问题。选哪个都是这个报错：`Error while applying chosen settings  (unknown regdomain Expected  eval: Use: not found)` 参见 <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287538>。替代方法是手动写，参照无线网络章节。
+  - freebsd 14.3 的 wifi country select 有问题。选哪个都是这个报错：`Error while applying chosen settings  (unknown regdomain Expected  eval: Use: not found)` 参见 <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287538>。替代方法是手动写，参照无线网络章节。
 - 2025.6.23
   - 3.6 文本编辑器新增：microsoft-edit
 - 2025.6.21


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 更正 2025 年第二季度更新日志中关于 FreeBSD 14.3 Wi-Fi 国家/地区选择的措辞错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct a wording typo in the 2025 Q2 changelog regarding FreeBSD 14.3 Wi-Fi country selection.

</details>