### PR TITLE
补遗

### DIFF
--- a/di-3-zhang-freebsd-install-more/di-3.5-jie-shuang-xi-tong-an-zhuang.md
+++ b/di-3-zhang-freebsd-install-more/di-3.5-jie-shuang-xi-tong-an-zhuang.md
@@ -116,7 +116,7 @@ vfs.zfs.vdev.min_auto_ashift: 9 -> 12
 
 ### 创建交换分区
 
-创建分区 freebsd-swap。
+在 nda0 磁盘上创建 4GB，4K 对齐的 FreeBSD 交换分区，并将其标记为 swap：
 
 ```sh
 # gpart add -a 4k -l swap -s 4G -t freebsd-swap nda0
@@ -134,13 +134,13 @@ vfs.zfs.vdev.min_auto_ashift: 9 -> 12
 
 ### 创建 ZFS 分区
 
-创建分区 freebsd-zfs。
+在 nda0 磁盘上创建 4K 对齐的 FreeBSD ZFS 分区，并标记为 zroot：
 
 ```sh
 # gpart add -a 4k -l zroot -t freebsd-zfs nda0
 ```
 
-将设置该分区卷标为 zroot，使用全部空余空间，请注意替换 nda0 为实际硬盘编号。
+将设置使用全部空余空间，请注意替换 nda0 为实际硬盘编号。
 
 #### 查看分区情况
 


### PR DESCRIPTION
## Summary by Sourcery

澄清在磁盘 nda0 上创建 swap 和 ZFS 分区的 FreeBSD 双启动安装说明。

文档：
- 扩展并澄清在 nda0 上创建 4GB、4K 对齐的 FreeBSD swap 分区的说明。
- 优化使用剩余磁盘空间创建 4K 对齐、标签为 zroot 的 FreeBSD ZFS 分区的描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the FreeBSD dual-boot installation instructions for creating swap and ZFS partitions on disk nda0.

Documentation:
- Expand and clarify instructions for creating a 4GB, 4K-aligned FreeBSD swap partition on nda0.
- Refine description of creating a 4K-aligned FreeBSD ZFS partition labeled zroot using remaining disk space.

</details>