### PR TITLE
更新 OpenBSD 的介绍

### DIFF
--- a/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
+++ b/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
@@ -86,7 +86,7 @@ OpenBSD 的 Bug 报告也缺乏统一的追踪、报告平台，仅通过邮件�
 
 ### 不稳定的 ABI
 
-据 Rust 维护者反馈（[OpenBSD support](https://github.com/rust-lang/rustup/issues/2168)），OpenBSD 的 ABI 十分不稳定，在这方面甚至和 Linux 接近。正因如此，Rust 团队无法通过 `rustup` 向 OpenBSD 用户发行预编译的 Rust 工具链。OpenBSD 用户只能通过 ports 获取该语言的工具链。
+据 Rust 维护者反馈（[OpenBSD support](https://github.com/rust-lang/rustup/issues/2168)），OpenBSD 的 ABI 十分不稳定，在这方面甚至和 Linux 接近。正因如此，Rust 团队无法通过 `rustup` 向 OpenBSD 用户发行预编译的 Rust 工具链。目前，OpenBSD 用户只能通过 ports 获取该语言的工具链，或者拉取源码自行编译。
 
 >OpenBSD 并不尝试保持向下兼容。在任意时刻，OpenBSD 仅支持两个稳定版本，同时还提供一个频繁更新的开发版本，称为 `-current`。一般来说，较旧稳定版中的二进制文件无法在较新的稳定版上运行。此外，也无法保证上周的 `-current` 构建出的二进制文件能在本周的 `-current` 上正常运行。
 


### PR DESCRIPTION
此分支介绍了向中国内地用户向 OpenBSD 基金会合规捐款的方式，并修正了有关 OpenBSD 上 Rust 支持情况的事实错误。

## Summary by Sourcery

更新 OpenBSD 介绍章节，更正有关 Rust 支持的信息，并新增关于中国大陆用户如何向 OpenBSD 基金会捐款的说明。

新功能：
- 记录中国大陆用户通过 PayPal 转账向 OpenBSD 基金会捐款的具体方法。

改进：
- 明确 Rust 在 OpenBSD 上支持的局限性，说明 rustup 无法分发预编译工具链，用户必须依赖 ports。
- 重新组织与捐赠相关的内容，删除先前带有抱怨语气的部分，改为中立、客观的捐赠方式说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the OpenBSD introduction chapter to correct information about Rust support and add guidance on how users in mainland China can donate to the OpenBSD Foundation.

New Features:
- Document a concrete method for mainland China users to donate to the OpenBSD Foundation via PayPal transfers.

Enhancements:
- Clarify the limitations of Rust support on OpenBSD by explaining that rustup cannot distribute precompiled toolchains and that users must rely on ports.
- Reorganize the donation-related content by removing an earlier complaint section and replacing it with a neutral, factual donation method section.

</details>