### PR TITLE
增补 Ob 捐款

### DIFF
--- a/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
+++ b/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
@@ -121,7 +121,7 @@ OpenBSD 的安全策略基于这样一种判断：超线程机制可能带来潜
 
 [Donating to the Foundation](https://www.openbsdfoundation.org/donations.html)，对于中国大陆的用户而言，向其捐赠存在一定困难，其只接受国际 PayPal，`此国家或地区不支持捐赠给此收款人`。我方已经发过邮件反馈过此事。笔者甚至写了一封挂号信给远在加拿大的 OpenBSD 基金会，但是很遗憾，还是没有任何回应。哪怕是采用 GitHub Sponsors 也是好的！后多方沟通仍遭拒绝。对此，笔者表示深切地遗憾，并对其未扩展捐赠渠道的原因提出疑问。
 
-目前，通过境内版本 PayPal 和普通银联储蓄卡可以直接向 PayPal 账号 `obsd-paypal@openbsdfoundation.org`（这是对方的账号，并非电子邮件）发起转账，进行捐赠。方法请读者自行搜索“PayPal 个人转账”。
+目前，通过境内版本 PayPal 和普通银联储蓄卡可以直接向 PayPal 账号 `obsd-paypal@openbsdfoundation.org`（这是对方的账号，并非电子邮件）发起转账，对 OpenBSD 基金会进行捐赠。方法请读者自行搜索“PayPal 个人转账”。
 
 ## OpenBSD 服务器与 OpenBSD VPS
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 重命名 OpenBSD 捐赠部分，并为中国大陆用户记录一种可行的基于 PayPal 的捐赠方式，该方式支持使用境内支付选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Rename the OpenBSD donation section and document a workable PayPal-based donation method using domestic payment options for mainland China users.

</details>