### PR TITLE
fix #1792

### DIFF
--- a/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
+++ b/di-26-zhang-openbsd/di-26.1-jie-gai-shu.md
@@ -86,7 +86,7 @@ OpenBSD 的 Bug 报告也缺乏统一的追踪、报告平台，仅通过邮件�
 
 ### 不稳定的 ABI
 
-据 Rust 维护者反馈（[OpenBSD support](https://github.com/rust-lang/rustup/issues/2168)），OpenBSD 的 ABI 十分不稳定，在这方面甚至和 Linux 接近。正因如此，将 Rust 引入 OpenBSD 面临较大困难。
+据 Rust 维护者反馈（[OpenBSD support](https://github.com/rust-lang/rustup/issues/2168)），OpenBSD 的 ABI 十分不稳定，在这方面甚至和 Linux 接近。正因如此，Rust 团队无法通过 `rustup` 向 OpenBSD 用户发行预编译的 Rust 工具链。目前，OpenBSD 用户只能通过 ports 获取该语言的工具链，或者拉取源码自行编译。
 
 >OpenBSD 并不尝试保持向下兼容。在任意时刻，OpenBSD 仅支持两个稳定版本，同时还提供一个频繁更新的开发版本，称为 `-current`。一般来说，较旧稳定版中的二进制文件无法在较新的稳定版上运行。此外，也无法保证上周的 `-current` 构建出的二进制文件能在本周的 `-current` 上正常运行。
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 扩展 OpenBSD ABI 章节，解释为什么 rustup 无法在 OpenBSD 上提供预编译的 Rust 工具链，以及用户可以选择的替代方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Expand the OpenBSD ABI section to explain why rustup cannot provide precompiled Rust toolchains on OpenBSD and what options users have instead.

</details>