### PR TITLE
增加 https://doc.bsdcn.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ EPUB 格式文档在手机上可使用 [微信读书](https://play.google.com/st
 
 - <https://book.bsdcn.org>
 - <https://docs.bsdcn.org>
+- <https://doc.bsdcn.org>（境内访问速度较佳）
 
 除此之外，FreeBSD 中文社区未对本书进行任何部署。我们唯一的域名只有 “bsdcn.org”。
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 新增 `doc.bsdcn.org` 作为备用文档域名，并注明其在中国大陆地区具有更好的访问性能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add doc.bsdcn.org as an alternative documentation domain with better mainland China access performance noted.

</details>