### PR TITLE
sysctl: unknown oid 'vfs.zfs.min_auto_ashift'

### DIFF
--- a/di-3-zhang-freebsd-install-more/di-3.12-aliyun.md
+++ b/di-3-zhang-freebsd-install-more/di-3.12-aliyun.md
@@ -511,7 +511,15 @@ pid 1562 (distextract), jid 0, uid 0, was killed: failed to reclaim memory
 # kldload zfs
 ```
 
-无任何信息输出则加载成功，可以继续进行安装流程。
+无任何信息输出则加载成功。
+
+或者还可以用以下命令验证 zfs 模块的加载情况：
+
+```sh
+# kldstat | grep zfs
+```
+
+如果有相关输出，则可以继续进行 bsdinstall 的安装流程。
 
 这可能是一个长期存在但难以复现的 Bug，参见 [Bug 249157 - installer reports sysctl: unknown oid 'vfs.zfs.min_auto_ashift' when ZFS module not loaded](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=249157)。
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 添加关于 `sysctl: unknown oid 'vfs.zfs.min_auto_ashift'` 错误的故障排查指南，包括如何加载并验证 ZFS 内核模块，以及链接到相关的 FreeBSD 缺陷报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add troubleshooting guidance for the `sysctl: unknown oid 'vfs.zfs.min_auto_ashift'` error, including loading and verifying the ZFS kernel module and linking to the related FreeBSD bug report.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- 添加关于 `sysctl: unknown oid 'vfs.zfs.min_auto_ashift'` 错误的故障排查指南，包括如何加载并验证 ZFS 内核模块，以及链接到相关的 FreeBSD 缺陷报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add troubleshooting guidance for the `sysctl: unknown oid 'vfs.zfs.min_auto_ashift'` error, including loading and verifying the ZFS kernel module and linking to the related FreeBSD bug report.

</details>

</details>