### PR TITLE
前置 zfs 模块加载

### DIFF
--- a/di-3-zhang-freebsd-install-more/di-3.12-aliyun.md
+++ b/di-3-zhang-freebsd-install-more/di-3.12-aliyun.md
@@ -201,30 +201,29 @@ default via 172.24.63.253 dev eth0 proto dhcp src 172.24.0.80 metric 100
 
 执行强制重启以进入 FreeBSD。
 
+根据读者反馈与实际测试，在半虚拟化平台上安装或升级 FreeBSD 时可能会遇到故障，例如阿里云的 VirtIO-BLK 存储设备驱动的问题。
+
 ![初次启动的 FreeBSD 系统](../.gitbook/assets/fb-zfs-1.png)
 
-
-根据读者反馈与实际测试，在 VMware ESXi 等虚拟化平台上安装或升级 FreeBSD 时可能会遇到故障（例如阿里云的 VirtIO-BLK 存储设备驱动的问题）。
+此时，需在 FreeBSD 系统启动时，在启动器菜单界面（上图所示界面），按下 **ESC** 键。进入命令提示符“OK”。
 
 ![调整可调参数](../.gitbook/assets/fb-zfs-1-1.png)
 
+请在该界面输入 `set kern.maxphys=65536`，设置内核最大物理 I/O 大小为 65536 字节，大块 I/O 有时会触发驱动或缓存问题，并按回车键进行确认，再输入 `boot` 按回车键方可正常启动。
 
-此时，需在 FreeBSD 系统启动时，在启动器菜单界面（上图所示界面），按下 **ESC** 键。进入命令提示符“OK”，随后输入 `set kern.maxphys=65536`（设置内核最大物理 I/O 大小为 65536 字节，大块 I/O 有时会触发驱动或缓存问题）进行确认，再输入 `boot` 方可正常启动。
+随后正常执行安装流程即可，选择 ZFS 分区方式。
 
+![安装 FreeBSD 系统](../.gitbook/assets/fb-zfs-1-2.png)
 
-FreeBSD 系统完全启动后：在引导加载器配置文件中设置最大 I/O 缓冲区大小：
+待 FreeBSD 系统完全启动后：在引导加载器配置文件中永久性设置最大 I/O 缓冲区大小：
 
 ```sh
 # echo "kern.maxphys=65536" >> /boot/loader.conf
 ```
 
-如果不进行上述设置，系统开机仍可能卡在引导界面。
+如果不进行上述设置，系统下次开机时仍可能卡在引导界面。
 
-正常执行安装流程，选择 ZFS 分区方式。
-
-![安装 FreeBSD 系统](../.gitbook/assets/fb-zfs-1-2.png)
-
-显示 FreeBSD 系统磁盘分区表及分区信息：
+再列出 FreeBSD 系统磁盘分区表及分区信息：
 
 ```sh
 root@freebsd:~ # gpart show


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 更新 Aliyun FreeBSD 安装指南，在运行 `bsdinstall` 之前增加关于加载并验证 ZFS 内核模块的说明，并进一步明确如何返回到 shell，以及如何检查分区和 `dmesg` 输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the Aliyun FreeBSD installation guide to instruct loading and verifying the ZFS kernel module before running bsdinstall and clarify how to return to the shell and inspect partition and dmesg output.

</details>