### PR TITLE
补遗

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.2-NVIDIA.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.2-NVIDIA.md
@@ -2,7 +2,7 @@
 
 ## NVIDIA 显卡驱动概述
 
-对于台式机，注意若 CPU 是英特尔处理器，且型号以 F 或者 KF 结尾的型号，是没有核芯显卡的，不需要处理核显相关配置。
+对于台式机，注意若 CPU 是英特尔处理器，且型号以 F（如 [i5-9400F](https://www.intel.cn/content/www/cn/zh/products/sku/190883/intel-core-i59400f-processor-9m-cache-up-to-4-10-ghz/specifications.html)）或者 KF（如 [i5-12600KF](https://www.intel.cn/content/www/cn/zh/products/sku/134590/intel-core-i512600kf-processor-20m-cache-up-to-4-90-ghz/specifications.html)）结尾的型号，是没有核芯显卡的，不需要处理核显相关配置。
 
 若你已拥有独立显卡，且你的视频输出（DP 或 HDMI）是直接插入的独立显卡。那么通常来说，你同样无需对核显进行任何配置，仅处理独显本身的驱动即可。
 
@@ -126,6 +126,10 @@ Mon Jan 19 19:06:59 2026
 - 用 MPV 打开一部电影，可以看到显存使用量明显上升（我是从 3 MB 上升到了数百兆），也可以用 SMPlayer 观看。
 
 ![](../.gitbook/assets/nvi1.jpg)
+
+## 参考文献
+
+- [关于我们的最新处理器和命名更新的简要指南](https://www.intel.cn/content/www/cn/zh/processors/processor-numbers.html)。英特尔官方关于 CPU 代号的说明。
 
 ## 故障排除
 


### PR DESCRIPTION
## Summary by Sourcery

澄清针对特定 Intel CPU 型号的 NVIDIA 桌面 GPU 驱动设置文档，并添加官方的 Intel 参考链接。

Documentation:
- 说明带有 F 或 KF 后缀的 Intel 桌面 CPU 不带集成显卡，并提供带有官方规格链接的具体型号示例。
- 添加一个参考部分，引用 Intel 关于 CPU 型号后缀的官方处理器命名指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify documentation on NVIDIA desktop GPU driver setup for specific Intel CPU models and add an official Intel reference link.

Documentation:
- Clarify that Intel desktop CPUs with F or KF suffixes lack integrated graphics and provide concrete model examples with official spec links.
- Add a reference section citing Intel’s official processor naming guide related to CPU model suffixes.

</details>