### PR TITLE
typo

### DIFF
--- a/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.5-jie-swap-jiao-huan-fen-qu-de-she-zhi.md
+++ b/di-23-zhang-wen-jian-xi-tong-yu-ci-pan-guan-li/di-23.5-jie-swap-jiao-huan-fen-qu-de-she-zhi.md
@@ -53,7 +53,7 @@ swapfile="/usr/swap0"
 
 在上述命令中：
 
-- `$(getconf PAGESIZE)` 可以返回磁盘块大小（固态硬盘通常会返回值 `4096`），从而使 swap 卷和系统页面对齐，以期提高性能
+- `$(getconf PAGESIZE)` 可以返回页面大小（固态硬盘通常会返回值 `4096`），从而使 swap 卷和系统页面对齐，以期提高性能
 - `-o` 用于指定选项，意为“option”：`-o 属性名=属性值`
 - `-o logbias=throughput`：ZFS 将优化同步操作，提高池的全局吞吐量并有效使用资源，可提高文件写入的性能
 - `-o sync=always`：强制所有写入实时同步


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 在交换分区配置指南中澄清：`$(getconf PAGESIZE)` 返回的是内存页大小，而不是磁盘块大小。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify that `$(getconf PAGESIZE)` returns the memory page size rather than disk block size in the swap configuration guide.

</details>