### PR TITLE
Change virtualbox-ose-additions to virtualbox-ose-additions-72

### DIFF
--- a/di-3-zhang-freebsd-install-more/di-3.3-jie-an-zhuang-freebsd-ji-yu-virtual-box.md
+++ b/di-3-zhang-freebsd-install-more/di-3.3-jie-an-zhuang-freebsd-ji-yu-virtual-box.md
@@ -105,21 +105,21 @@
 - 使用 pkg 安装：
 
 ```sh
-# pkg install virtualbox-ose-additions
+# pkg install virtualbox-ose-additions-72
 ```
 
 或者使用 Ports：
 
 ```sh
-# cd /usr/ports/emulators/virtualbox-ose-additions/
+# cd /usr/ports/emulators/virtualbox-ose-additions-72/
 # make install clean
 ```
 
 ## 查看安装说明
 
 ```sh
-root@ykla:/home/ykla # pkg info -D virtualbox-ose-additions
-virtualbox-ose-additions-6.1.50.1401000:
+root@ykla:/home/ykla # pkg info -D virtualbox-ose-additions-72
+virtualbox-ose-additions-7.2.6.1500068:
 On install:
 VirtualBox Guest Additions are installed.
 # VirtualBox 客户端增强功能已安装。


### PR DESCRIPTION
参见：https://www.freshports.org/emulators/virtualbox-ose-additions/

DEPRECATED: Upstream EOL reaches on 2024-01-31, use emulators/virtualbox-ose-additions-72 instead
EXPIRATION DATE: 2026-12-31

## 由 Sourcery 提供的摘要

文档：
- 在 VirtualBox 来宾增强功能安装指南中，调整命令和示例，使其使用 `virtualbox-ose-additions-72` 软件包/端口及其当前版本信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Adjust commands and examples to use the virtualbox-ose-additions-72 package/port and its current version information in the VirtualBox guest additions installation guide.

</details>