### PR TITLE
docs: 修正 Xray/V2Ray 命令并补充 FreeBSD 服务配置指南

### DIFF
--- a/di-10-zhang-vpn-yu-dai-li/di-10.2-jie-v2ray.md
+++ b/di-10-zhang-vpn-yu-dai-li/di-10.2-jie-v2ray.md
@@ -36,7 +36,7 @@ V2Ray、Xray-core 配置基本相同，配置文档可以在各自的官方文�
 
 ## 启动代理软件
 
-如果事先已有代理客户端，可以将客户端节点配置导出并复制到 FreeBSD 系统中（如使用 Windows 版本的 V2rayN 导出），假设导出的文件名为 `config.json`，然后执行以下命令。
+如果事先已有代理客户端，可以将客户端节点配置导出并复制到 FreeBSD 系统中（如使用 Windows 版本的 V2RayN 导出），假设导出的文件名为 `config.json`，然后执行以下命令：
 
 - 使用指定的配置文件启动 V2Ray：
 
@@ -138,13 +138,12 @@ Shell 配置路径
 3. csh： ~/.cshrc 写入 B 组配置
 
 A 组（sh/bash）
-复制
+
 ```sh
 export XRAY_LOCATION_ASSET=/usr/local/share/xray-core/      # 指定 Xray 资源文件路径
 ```
 
 B 组（csh）
-复制
 
 ```sh
 setenv XRAY_LOCATION_ASSET /usr/local/share/xray-core/
@@ -152,7 +151,7 @@ setenv XRAY_LOCATION_ASSET /usr/local/share/xray-core/
 
 配置完成后，请源化配置文件以使更改立即生效（例如，对于 sh 或 bash：source ~/.profile；对于 csh：source ~/.cshrc），或注销并重新登录。对于系统服务运行方式（如 rc.conf），无需此配置，因为它通过 sysrc 注入环境变量。
 
-**物理软链接**
+**创建符号链接**
 
 建立软链接，使 Xray 无论从何处启动都能找到数据库：
 


### PR DESCRIPTION
1. 修正 V2Ray/Xray 启动命令，增加新的 'run' 子命令支持。
2. 针对 FreeBSD 路径特殊性，补充了 XRAY_LOCATION_ASSET 环境变量的设置方法。
3. 增加通过 rc.d 系统管理 Xray 服务的详细步骤（包含权限处理和配置目录规范）。
4. 补充 Firefox 浏览器代理设置及 SOCKS5 DNS 远程解析的配置建议。

## 由 Sourcery 提供的摘要

更新 FreeBSD 上的 V2Ray/Xray 使用文档，包括修正启动命令、资产文件的环境配置、系统服务设置以及浏览器代理使用说明。

文档内容：
- 修正 V2Ray/Xray 启动示例，使用新的 `run` 子命令和显式的配置文件路径。
- 记录 `XRAY_LOCATION_ASSET` 的用法，以及在 FreeBSD 上解决 geosite/geoip 资产加载问题的替代方法。
- 添加将 Xray 作为 FreeBSD `rc.d` 服务进行管理的分步说明，包括配置文件放置位置和权限设置。
- 扩展 Firefox 配置指引，加入 SOCKS5 端口使用说明，以及通过 DNS-over-SOCKS 避免 DNS 污染的建议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 V2Ray/Xray FreeBSD 使用指南，改进启动示例，并补充资产加载与服务管理的故障排查内容。

文档更新内容：
- 使用新的 `run` 子命令和显式配置路径，澄清 V2Ray/Xray 启动命令。
- 扩展 Firefox 代理配置说明，包括 SOCKS5 的使用以及 DNS-over-SOCKS 的推荐配置。
- 新增针对 Xray 在 FreeBSD 上通过 `XRAY_LOCATION_ASSET` 和符号链接加载资产文件失败时的故障排查说明。
- 记录如何将 Xray 作为 FreeBSD rc.d 服务进行管理，包括配置目录放置位置、权限设置以及 `rc.conf` 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the V2Ray/Xray FreeBSD usage guide with improved startup examples and troubleshooting for asset loading and service management.

Documentation:
- Clarify V2Ray/Xray startup commands using the new run subcommand and explicit config paths.
- Expand Firefox proxy configuration guidance, including SOCKS5 usage and DNS-over-SOCKS recommendations.
- Add troubleshooting instructions for Xray asset file loading failures via XRAY_LOCATION_ASSET and symlinks on FreeBSD.
- Document managing Xray as a FreeBSD rc.d service, including config directory placement, permissions, and rc.conf settings.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 FreeBSD 上的 V2Ray/Xray 使用文档，包括修正启动命令、资产文件的环境配置、系统服务设置以及浏览器代理使用说明。

文档内容：
- 修正 V2Ray/Xray 启动示例，使用新的 `run` 子命令和显式的配置文件路径。
- 记录 `XRAY_LOCATION_ASSET` 的用法，以及在 FreeBSD 上解决 geosite/geoip 资产加载问题的替代方法。
- 添加将 Xray 作为 FreeBSD `rc.d` 服务进行管理的分步说明，包括配置文件放置位置和权限设置。
- 扩展 Firefox 配置指引，加入 SOCKS5 端口使用说明，以及通过 DNS-over-SOCKS 避免 DNS 污染的建议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 V2Ray/Xray FreeBSD 使用指南，改进启动示例，并补充资产加载与服务管理的故障排查内容。

文档更新内容：
- 使用新的 `run` 子命令和显式配置路径，澄清 V2Ray/Xray 启动命令。
- 扩展 Firefox 代理配置说明，包括 SOCKS5 的使用以及 DNS-over-SOCKS 的推荐配置。
- 新增针对 Xray 在 FreeBSD 上通过 `XRAY_LOCATION_ASSET` 和符号链接加载资产文件失败时的故障排查说明。
- 记录如何将 Xray 作为 FreeBSD rc.d 服务进行管理，包括配置目录放置位置、权限设置以及 `rc.conf` 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the V2Ray/Xray FreeBSD usage guide with improved startup examples and troubleshooting for asset loading and service management.

Documentation:
- Clarify V2Ray/Xray startup commands using the new run subcommand and explicit config paths.
- Expand Firefox proxy configuration guidance, including SOCKS5 usage and DNS-over-SOCKS recommendations.
- Add troubleshooting instructions for Xray asset file loading failures via XRAY_LOCATION_ASSET and symlinks on FreeBSD.
- Document managing Xray as a FreeBSD rc.d service, including config directory placement, permissions, and rc.conf settings.

</details>

</details>

</details>