### PR TITLE
更新 Rocky Linux 兼容层版本，移出无实质性内容

### DIFF
--- a/di-21-zhang-linux-jian-rong-ceng/di-21.2-jie-rocky9-jian-rong-ceng.md
+++ b/di-21-zhang-linux-jian-rong-ceng/di-21.2-jie-rocky9-jian-rong-ceng.md
@@ -1,12 +1,12 @@
 # 21.2 通过 FreeBSD Ports 安装 Rocky Linux 兼容层
 
-截至 2024 年 11 月 19 日，Ports/包 [emulators/linux-rl9](https://www.freshports.org/emulators/linux-rl9/) 基于 Rocky Linux 9.5（Rocky Linux 发布于 2024 年 11 月 19 日）：
+截至 2026 年 2 月 16 日，Ports/包 [emulators/linux-rl9](https://www.freshports.org/emulators/linux-rl9/) 基于 Rocky Linux 9.7：
 
 查看当前 Linux 发行版的版本信息：
 
 ```sh
-bash-5.1$ cat /etc/redhat-release 
-Rocky Linux release 9.5 (Blue Onyx)
+bash-5.1$ cat /etc/redhat-release      # Rocky Linux 兼容层内
+Rocky Linux release 9.7 (Blue Onyx)
 ```
 
 ## 启用 Linux 兼容层服务


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 更新 Rocky Linux 兼容层部分，以引用基于 Rocky Linux 9.7 的 `linux-rl9` 移植版本，并对示例版本检查命令添加注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Refresh the Rocky Linux compatibility layer section to reference the Rocky Linux 9.7-based linux-rl9 port and annotate the example version check command.

</details>