### PR TITLE
补充源代码细节

### DIFF
--- a/di-21-zhang-linux-jian-rong-ceng/di-21.2-jie-rocky9-jian-rong-ceng.md
+++ b/di-21-zhang-linux-jian-rong-ceng/di-21.2-jie-rocky9-jian-rong-ceng.md
@@ -13,23 +13,23 @@ Rocky Linux release 9.7 (Blue Onyx)
 
 观察提交 [emulators/linux_base-rl9: update to Rocky Linux 9.7 (+)](https://github.com/freebsd/freebsd-ports/commit/3eb21a5228ef7b1c30886e17ad3f53b0066e1fa9)，可以发现，真正决定了版本号的是 Ports 框架中的 [Mk/Uses/linux.mk](https://github.com/freebsd/freebsd-ports/blob/main/Mk/Uses/linux.mk)‎ 文件中的 `LINUX_DIST_VER` 变量的值：
 
-```c
+```make
 .  if empty(linux_ARGS)
-.    if exists(${LINUXBASE}/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7)  // 检查兼容层内是否存在文件 RPM-GPG-KEY-CentOS-7，若有则为 CentOS 7 兼容层
+.    if exists(${LINUXBASE}/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7)  # 检查兼容层内是否存在文件 RPM-GPG-KEY-CentOS-7，若有则为 CentOS 7 兼容层
 linux_ARGS=		c7
-.    elif exists(${LINUXBASE}/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9) // 检查兼容层内是否存在文件 RPM-GPG-KEY-Rocky-9，若有则为 Rocky Linux 9 兼容层
+.    elif exists(${LINUXBASE}/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9) # 检查兼容层内是否存在文件 RPM-GPG-KEY-Rocky-9，若有则为 Rocky Linux 9 兼容层
 linux_ARGS=		rl9
 .    else
 linux_ARGS=		${LINUX_DEFAULT}
 .    endif
 .  endif
 
-.  if ${linux_ARGS} == c7  // 检查是不是 CentOS 7 兼容层
-LINUX_DIST_VER?=	7.9.2009    // 当前引入的是 CentOS 7.9.2009
-.  elif ${linux_ARGS} == rl9   // 检查是不是 Rocky Linux 9 兼容层
-LINUX_DIST_VER?=	9.7  // 当前引入的是 Rocky Linux 9.7
+.  if ${linux_ARGS} == c7  # 检查是不是 CentOS 7 兼容层
+LINUX_DIST_VER?=	7.9.2009    # 当前引入的是 CentOS 7.9.2009
+.  elif ${linux_ARGS} == rl9   # 检查是不是 Rocky Linux 9 兼容层
+LINUX_DIST_VER?=	9.7  # 当前引入的是 Rocky Linux 9.7
 .  else
-ERROR+=			"Invalid Linux distribution: ${linux_ARGS}"  // 如果都不是则直接打印报错信息
+ERROR+=			"Invalid Linux distribution: ${linux_ARGS}"  # 如果都不是则直接打印报错信息
 .  endif
 ```
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 更新 Rocky Linux 9 兼容层部分，使其引用正确的底层 linux_base 端口，并记录 `LINUX_DIST_VER` 是如何从 Ports 框架中推导出来的，而不是从 `/etc/redhat-release` 中获取。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the Rocky Linux 9 compatibility layer section to reference the correct underlying linux_base port and document how LINUX_DIST_VER is derived from the Ports framework rather than /etc/redhat-release.

</details>