### PR TITLE
ee 编辑器已支持中文

### DIFF
--- a/di-4-zhang-freebsd-base/di-4.6-jie-bian-ji-qi.md
+++ b/di-4-zhang-freebsd-base/di-4.6-jie-bian-ji-qi.md
@@ -2,10 +2,6 @@
 
 ## `ee` 编辑器基本用法
 
->**注意**
->
->`ee` 编辑器不支持中文。已经报告 Bug [Bug 291279 - [Feature Request] Add UTF-8 Support to ee(1)](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=291279)。
-
 `ee` 是 FreeBSD 基本系统内置的编辑器。
 
 `ee` 的用法比 [nano](https://www.redhat.com/zh/blog/getting-started-nano) [备份](https://web.archive.org/web/20260121060144/https://www.redhat.com/zh-cn/blog/getting-started-nano)（一款 GNU 编辑器）还要简单许多，从其名字“easy editor”（简单的编辑器）即可看出。


### PR DESCRIPTION
根据 https://reviews.freebsd.org/D55303 以及 https://cgit.freebsd.org/src/commit/?id=62fba0054d9eb2303116f54be1f9bc0e7b75cc15 ，目前 FreeBSD 16-CURRENT 已经引入 UTF-8 支持，比如中文

## Summary by Sourcery

Documentation:
- 移除过时的说明，该说明声称 ee 编辑器不支持中文/UTF-8。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Remove outdated note claiming the ee editor does not support Chinese/UTF-8.

</details>