### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2026 年第一季度
 
-- 2026.2.1
+- 2026.2.18
   - “21.2 通过 FreeBSD Ports 安装 Rocky Linux 兼容层”新增“Rocky Linux 版本号概述”
+  - 根据 <https://reviews.freebsd.org/D55303> 以及 <https://cgit.freebsd.org/src/commit/?id=62fba0054d9eb2303116f54be1f9bc0e7b75cc15>，目前 FreeBSD 16-CURRENT 已经引入 UTF-8 支持，如中文。本地测试通过
 - 2026.2.15
   - “4.2 Linux 用户迁移指南”新增：“理解 FreeBSD 并非发行版而是操作系统”
 - 2026.2.14


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 通过更新日期并添加关于 FreeBSD 16-CURRENT 中已确认的 UTF-8 支持的说明，澄清 2026 年第一季度的更新日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify the 2026 Q1 changelog with an updated date and notes about confirmed UTF-8 support in FreeBSD 16-CURRENT.

</details>