### PR TITLE
typo

### DIFF
--- a/di-21-zhang-linux-jian-rong-ceng/di-21.4-jie-linux-jian-rong-ceng-ji-yu-archlinux-bootstrap.md
+++ b/di-21-zhang-linux-jian-rong-ceng/di-21.4-jie-linux-jian-rong-ceng-ji-yu-archlinux-bootstrap.md
@@ -6,7 +6,7 @@
 >
 >即使切换到 zsh 也无效，TTY 会报错：`linux: jid 0 pid 1154 (bash): linux_ioctl_fallback fd=0, cmd=0x802c542a ('T',42) is not implemented`。
 >
->该 Bug 声称由 [linux: support termios2 ioctls](https://github.com/freebsd/freebsd-src/pull/1949) 已在 FreeBSD 15.0-STABLE 解决。
+>该 Bug 声称由 [linux: support termios2 ioctls](https://github.com/freebsd/freebsd-src/pull/1949) 的修改已在 FreeBSD 15.0-STABLE 中解决。
 
 视频教程：[07-FreeBSD-Arch Linux 兼容层脚本使用说明](https://www.bilibili.com/video/BV1wg4y1w7QV)
 


### PR DESCRIPTION
## Summary by Sourcery

更新 Arch Linux 兼容层文档，以纠正 FreeBSD 版本信息并提供更清晰的引导（bootstrap）设置说明。

文档：
- 说明所引用的 `termios2 ioctl` 缺陷在具体哪个 FreeBSD 版本中已得到修复。
- 更新 Arch Linux 引导环境的目录名称、解压路径及相关说明，以提高准确性和清晰度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Arch Linux compatibility layer documentation for corrected FreeBSD version information and clearer bootstrap setup instructions.

Documentation:
- Clarify the FreeBSD version in which the referenced termios2 ioctl bug is resolved.
- Update Arch Linux bootstrap directory names, extraction paths, and accompanying explanations for improved accuracy and clarity.

</details>