### PR TITLE
typo

### DIFF
--- a/di-24-zhang-kernel/di-24.5-jie-build-freebsd-on-linux.md
+++ b/di-24-zhang-kernel/di-24.5-jie-build-freebsd-on-linux.md
@@ -52,15 +52,6 @@
 ……省略一部分日志输出……
 ```
 
-
-## 创建放置构建产物的目录
-
-创建目录 `bsdobj`；若其父目录不存在，则一并创建：
-
-```sh
-$ mkdir -p /home/ykla/bsdobj 
-```
-
 ## 使用 git 拉取 FreeBSD 源代码
 
 拉取 FreeBSD 源码仓库：
@@ -70,8 +61,17 @@ $ cd /home/ykla                                     # 切换到用户主目录
 $ git clone --depth 1 https://github.com/freebsd/freebsd-src  # 以浅克隆方式拉取 FreeBSD 源码仓库
 ```
 
-拉取完成后，源代码应位于 `/home/ykla/freebsd-src`（`freebsd-src` 目录由 Git 自动创建）。
+拉取完成后，源代码应位于 `/home/ykla/freebsd-src`（目录 `freebsd-src` 由 Git 自动创建）。
 
+## 创建放置构建产物的目录
+
+创建目录 `bsdobj`；
+
+```sh
+$ mkdir -p /home/ykla/bsdobj 
+```
+
+选项 `-p`：若其父目录不存在，则一并创建。
 
 ## 构建工具链与世界（用户空间）
 
@@ -122,7 +122,6 @@ $ MAKEOBJDIRPREFIX=/home/ykla/bsdobj tools/build/make.py --bootstrap-toolchain -
 ```
 
 除末尾的 `kernel-toolchain` 不同外，其余选项参数均保持一致。
-
 
 验证结果：
 
@@ -202,3 +201,4 @@ FreeBSD 15.0 已不再支持任何 32 位架构。
 - [FreeBSD 手册](https://docs.freebsd.org/en/books/handbook/cutting-edge/#building-on-non-freebsd-hosts) [备份](https://web.archive.org/web/20260116210848/https://docs.freebsd.org/en/books/handbook/cutting-edge/#building-on-non-freebsd-hosts)，26.9. Building on non-FreeBSD Hosts，只提供了基本思路，参考价值有限
 - [Building on non-FreeBSD hosts](https://wiki.freebsd.org/BuildingOnNonFreeBSD) [备份](https://web.archive.org/web/20260117180234/https://wiki.freebsd.org/BuildingOnNonFreeBSD)，仅提供基本思路，参考价值有限
 - [man src.conf](https://man.freebsd.org/cgi/man.cgi?src.conf)，构建参数参考此处
+- [cross-bootstrap-tools.yml](https://github.com/freebsd/freebsd-src/blob/main/.github/workflows/cross-bootstrap-tools.yml)，FreeBSD 项目自身使用的交叉编译 CI


### PR DESCRIPTION
## Summary by Sourcery

澄清并稍微重组 FreeBSD-on-Linux 的构建文档。

文档：
- 改进关于克隆 FreeBSD 源码树的说明，并明确指出 Git 会创建目标目录。
- 移动并扩展关于创建 `bsdobj` 构建输出目录的章节，包括对 `-p` 标志的解释。
- 增加对 FreeBSD 交叉编译 CI 工作流（`cross-bootstrap-tools.yml`）的引用，供进一步阅读。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and slightly reorganize FreeBSD-on-Linux build documentation.

Documentation:
- Refine instructions for cloning the FreeBSD source tree and clarify that Git creates the target directory.
- Move and expand the section on creating the `bsdobj` build output directory, including an explanation of the `-p` flag.
- Add a reference to FreeBSD's cross-compilation CI workflow (`cross-bootstrap-tools.yml`) as further reading.

</details>