### PR TITLE
Add troubleshooting steps for KDE theme display

### DIFF
--- a/di-6-zhang-zhuo-mian-an-zhuang/di-6.3-jie-an-zhuang-kde.md
+++ b/di-6-zhang-zhuo-mian-an-zhuang/di-6.3-jie-an-zhuang-kde.md
@@ -170,11 +170,13 @@ Current=sddm-freebsd-black-theme
 
  ![KDE 6 FreeBSD 主题](../.gitbook/assets/kde-theme.png)
 
-如果遇到仍无法显示主题的问题，页面仍为默认界面，你需要执行 [已反馈，等待解决](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=293449) [备份](https://web.archive.org/web/20260225213341/https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=293449) :
+如果读者遇到无法切换主题的问题（仍为默认界面），需要执行  :
 
-```
+```sh
 # ln -s /usr/local/bin/sddm-greeter-qt6 /usr/local/bin/sddm-greeter
 ```
+
+此问题已反馈至 [x11-themes/sddm-freebsd-black-theme incompatible with SDDM 0.21.0 (Qt6 greeter)](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=293449) [备份](https://web.archive.org/web/20260225213341/https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=293449)，待解决。
 
 ### 参考文献
 


### PR DESCRIPTION
Added instructions for resolving theme display issues in KDE. 
refer: https://forums.freebsd.org/threads/sddm-greeter.98389/

## Summary by Sourcery

Documentation:
- 添加一条故障排除说明，展示如何为 `sddm-greeter` 创建符号链接，以修复 SDDM 上 KDE 主题显示问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a troubleshooting note showing how to create a symlink for sddm-greeter to fix KDE theme display issues on SDDM.

</details>