### PR TITLE
Linux kernel licensing rules

### DIFF
--- a/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
+++ b/di-1-zhang-zou-jin-freebsd/di-1.1-unix.md
@@ -106,7 +106,7 @@ Multics 意图创造强悍的新软件和比肩 IBM 7094 功能更丰富的新�
 
 ## GNU 与自由软件运动
 
-根据 Linux 内核文档 [1.5. Licensing](https://www.kernel.org/doc/html/latest/process/1.Intro.html)：
+根据 Linux 内核文档 [1.5. Licensing](https://www.kernel.org/doc/html/latest/process/1.Intro.html)（另见 [Linux kernel licensing rules](https://www.kernel.org/doc/html/latest/process/license-rules.html)）：
 
 >Code is contributed to the Linux kernel under a number of licenses, but all code must be compatible with version 2 of the GNU General Public License (GPLv2), which is the license covering the kernel distribution as a whole. In practice, that means that all code contributions are covered either by GPLv2 (with, optionally, language allowing distribution under later versions of the GPL) or the three-clause BSD license. Any contributions which are not covered by a compatible license will not be accepted into the kernel.（Linux 内核中的代码是在多种许可证之下被贡献的，但所有代码都必须与 GNU 通用公共许可证第 2 版（ GPLv2 ）兼容，而该许可证覆盖了所有内核发行文件。实际上，这意味着所有对代码的贡献要么受 GPLv2 约束（可选地包含允许在 GPL 后续版本下发布的条款），要么受三条款 BSD 许可证约束。任何未被兼容许可证覆盖的贡献都不会被接纳进内核。）
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 通过添加对 Linux 内核许可规则文档的直接引用，澄清 Linux 内核许可部分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify Linux kernel licensing section by adding a direct reference to the Linux kernel licensing rules documentation.

</details>