### PR TITLE
更新 Minecraft 启动方式

### DIFF
--- a/di-20-zhang-yu-le-yu-jiao-yu/20.2-minecraft.md
+++ b/di-20-zhang-yu-le-yu-jiao-yu/20.2-minecraft.md
@@ -42,7 +42,11 @@ PrismLauncher 是一款使用 C++ 和 Qt 框架开发的开源启动器。
 
 #### HMCL 启动器
 
-HMCL 使用 Java 语言开发，从 [releases](https://github.com/HMCL-dev/HMCL/releases) [备份](https://web.archive.org/web/20260116224548/https://github.com/HMCL-dev/HMCL/releases) 页面下载最新的发行版本。
+HMCL 使用 Java 语言开发。
+
+##### 配置 HMCL启动器
+
+从 [releases](https://github.com/HMCL-dev/HMCL/releases) [备份](https://web.archive.org/web/20260116224548/https://github.com/HMCL-dev/HMCL/releases) 页面下载最新的发行版本。
 
 打开终端执行命令，使用 Java 运行 HMCL 启动器的 JAR 文件：
 


### PR DESCRIPTION
* 新增 PrismLauncher 启动器介绍
* 更改教程 JDK 版本为 openjdk21，受长期支持，OpenJDK 23 已经完全停止维护

## 由 Sourcery 提供的摘要

更新 FreeBSD 上的 Minecraft 文档，以使用 OpenJDK 21，并记录多种桌面启动器。

文档更新内容：
- 将桌面和服务器的安装说明从 OpenJDK 23 切换为 OpenJDK 21，包括 `pkg` 和 ports 的示例。
- 添加在 FreeBSD 上使用 PrismLauncher 作为 Minecraft 启动器替代方案（与 HMCL 并存）的文档，并相应调整章节结构。
- 将已测试的 Minecraft 服务器环境说明从 FreeBSD 14.2 更新为 FreeBSD 15.0。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Minecraft on FreeBSD documentation to use OpenJDK 21 and document multiple desktop launchers.

Documentation:
- Switch desktop and server setup instructions from OpenJDK 23 to OpenJDK 21, including pkg and ports examples.
- Add documentation for using PrismLauncher as an alternative Minecraft launcher on FreeBSD alongside HMCL, and adjust section structure accordingly.
- Update the tested Minecraft server environment reference from FreeBSD 14.2 to FreeBSD 15.0.

</details>