### PR TITLE
更新 FreeBSD 及 llvm版本

### DIFF
--- a/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
+++ b/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
@@ -4,20 +4,19 @@
 
 FreeBSD 基本系统内置 Clang 编译器，但并不包含 LLVM 中的其他组件，如 clangd（语言服务器，用于代码补全、编译错误提示和定义跳转等）、Clang-Tidy（代码风格诊断器）以及 clang-format（用于格式化 C/C++ 代码）。
 
-因此需要安装 LLVM，这里可以使用各个版本的 LLVM，但其版本至少不应低于系统自带的 Clang。在 FreeBSD 14.2 中，基本系统中的 Clang 版本为 18。
+因此需要安装 LLVM，这里可以使用各个版本的 LLVM，但其版本至少不应低于系统自带的 Clang。在 FreeBSD 15.0-RELEASE 中，基本系统中的 Clang 版本为 19。
 
 查看 Clang 编译器的版本信息：
 
 ```sh
 # clang -v
-FreeBSD clang version 18.1.6 (https://github.com/llvm/llvm-project.git llvmorg-18.1.6-0-g1118c2e05e67)
-Target: x86_64-unknown-freebsd14.2
+FreeBSD clang version 19.1.7 (https://github.com/llvm/llvm-project.git llvmorg-19.1.7-0-gcd708029e0b2)
+Target: x86_64-unknown-freebsd15.0
 Thread model: posix
 InstalledDir: /usr/bin
 ```
 
 下文使用 LLVM 20，安装后对应的程序名为 clang20、clang++20、clangd20 和 clang-format20。系统自带的 Clang 程序名为 `clang`。如果使用不同版本，请注意对应的程序名称。
-
 
 ## 安装 Clang 环境包
 
@@ -356,4 +355,3 @@ $ cmake ..                   # 运行 CMake 配置上级目录的项目
 ## 参考文献
 
 - [algcl](https://github.com/Jianping-Duan/algcl) [备份](https://web.archive.org/web/20260121064214/https://github.com/Jianping-Duan/algcl)，一些可直接运行于 FreeBSD 的 C 语言算法与数据结构编程实例。
-  


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 更新文档示例，将原先引用的 FreeBSD 14.2 与 Clang 18 改为 FreeBSD 15.0-RELEASE 与 Clang 19，并清理结尾多余内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Refresh documentation examples to reference FreeBSD 15.0-RELEASE with Clang 19 instead of FreeBSD 14.2 with Clang 18, and clean up trailing content.

</details>