### PR TITLE
减缓 CI 频率

### DIFF
--- a/.github/workflows/count-chinese.yml
+++ b/.github/workflows/count-chinese.yml
@@ -2,7 +2,7 @@ name: 📊 更新文档字数统计
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '20 5 * * 0'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 将文档字数统计工作流程的定时任务从“每天运行”修改为“每周日在运行一次”。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Change the cron schedule of the documentation word count workflow to run once a week on Sundays instead of every day.

</details>