### PR TITLE
从源代码解释 Clang 版本概述

### DIFF
--- a/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
+++ b/di-22-zhang-bian-cheng-yu-kai-fa/di-22.4-jie-cc++-huan-jing-de-pei-zhi.md
@@ -36,7 +36,7 @@ if(NOT DEFINED LLVM_VERSION_MAJOR)
 
 #### FreeBSD 基本系统中的 LLVM 版本号
 
-FreeBSD 将 LLVM 导入了基本系统源代码中，但是不是直接导入，而是经过了一定的处理，写作文章时 FreeBSD src 内置的 LLVM 仍为 LLVM 19，故而，注明版本号的文件路径位于 [lib/clang/Finclude/clang/Basic/Version.inc](https://github.com/freebsd/freebsd-src/blob/main/lib%2Fclang%2Finclude%2Fclang%2FBasic%2FVersion.inc)：
+FreeBSD 将 LLVM 导入了基本系统源代码中，但是不是直接导入，而是经过了一定的处理，写作文章时 FreeBSD src 内置的 LLVM 仍为 LLVM 19，故而，注明版本号的文件路径位于 [lib/clang/include/clang/Basic/Version.inc](https://github.com/freebsd/freebsd-src/blob/main/lib%2Fclang%2Finclude%2Fclang%2FBasic%2FVersion.inc)：
 
 ```c
 #define	CLANG_VERSION			19.1.7


### PR DESCRIPTION
增补 #1907

## Summary by Sourcery

在 C/C++ 环境配置章节中，记录 Clang 在上游 LLVM 和 FreeBSD 基础系统中的版本来源与演变。

文档内容：
- 说明上游 LLVM 在源码树中定义版本号的位置，以及在 LLVM 19 之后这一机制是如何变化的。
- 描述 FreeBSD 基础系统如何跟踪并定义其内置的 LLVM/Clang 版本，并给出版本宏示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document Clang versioning origins in both upstream LLVM and FreeBSD’s base system within the C/C++ environment setup chapter.

Documentation:
- Explain where upstream LLVM defines its version number in the source tree and how it changed after LLVM 19.
- Describe how FreeBSD’s base system tracks and defines its bundled LLVM/Clang version, with example version macros.

</details>