### PR TITLE
补遗

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - 2026.2.28
   - 新增“3.13 基于 Apple M1 和 UTM 安装 FreeBSD”
+  - 将“5.3 gitup 的用法”合并入 5.4 作为附录，作拟删除处理。原因：缺乏实质性维护近 2 年
   - 删除“21.5 基于 archlinux-pacman 的 Arch Linux 兼容层（拟删除）”。原因：存在 Bug 287690 [sysutils/pacman: The archlinux flavor cannot be built or installed.](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287690) 无法得到解决
   - 删除“6.10 Budgie（拟删除）”，原因：欠缺维护，存在 [Bug 289898 x11/budgie: After logging in with LightDM, it crashes and then shows a black screen](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289898) 无法得到解决
   - 将“附录：登录界面主题”从“6.3 KDE 6（X11 会话）”彻底删除，因为软件源中仅存在 Port x11-themes/sddm-freebsd-black-theme，且无人维护，存在 [x11-themes/sddm-freebsd-black-theme incompatible with SDDM 0.21.0 (Qt6 greeter)](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=293449) 无法得到解决


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 记录：`gitup` 使用部分已作为附录合并到 5.4 节中，并被标记为计划删除，因为该部分已近两年未得到有效维护。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Record that the gitup usage section has been merged into section 5.4 as an appendix and marked for planned deletion because it has not been meaningfully maintained for nearly two years.

</details>