### PR TITLE
删除不生效的参数

### DIFF
--- a/di-13-zhang-freebsd-te-se/di-13.7-jie-conf.md
+++ b/di-13-zhang-freebsd-te-se/di-13.7-jie-conf.md
@@ -31,7 +31,6 @@
 
 default:\
 	:passwd_format=sha512:\ # 新建或更改密码将使用的加密格式。类型为字符串。有效值为 `"des"`、`"md5"`、`"blf"`、`"sha256"` 和 `"sha512"`；详细信息请参见 `crypt(3)`。使用非 FreeBSD NIS 服务器的 NIS 客户端通常应使用 `"des"`。
-	:copyright=/etc/COPYRIGHT:\ # 区分操作系统版权信息与在每次用户登录时额外显示的信息。实际上不存在该文件。cp /COPYRIGHT /etc/。实际上不生效
 	:welcome=/var/run/motd:\  # 登录后会看到的信息
 	:setenv=BLOCKSIZE=K:\  # 由逗号分隔的环境变量及其对应值的列表。包含逗号的值必须加引号。`BLOCKSIZE=K` 即让命令以 KB 大小格式显示
 	:mail=/var/mail/$:\  # 将环境变量 `$MAIL` 设置为指定的值。
@@ -130,7 +129,6 @@ russian|Russian Users Accounts:\
 ## standard - 标准用户默认值
 ##
 #standard:\
-#	:copyright=/etc/COPYRIGHT:\
 #	:welcome=/var/run/motd:\
 #	:setenv=BLOCKSIZE=K:\
 #	:mail=/var/mail/$:\


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 更新 FreeBSD 登录配置文档，从示例配置中移除未使用的 `:copyright:` 参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update FreeBSD login configuration documentation to drop the unused :copyright: parameter from example configurations.

</details>