### PR TITLE
补遗

### DIFF
--- a/di-18-zhang-qian-ru-shi-ping-tai/di-18.5-jie-tong-yong-qian-ru-shi-kai-fa-huan-jing.md
+++ b/di-18-zhang-qian-ru-shi-ping-tai/di-18.5-jie-tong-yong-qian-ru-shi-kai-fa-huan-jing.md
@@ -407,14 +407,14 @@ $ idf.py build                     # 使用 xtensa-esp-elf-gcc 编译
 使用 esptool.py 烧录：
 
 ```sh
-$ esptool.py --chip esp32 --port /dev/cuaU0 --baud 921600 write_flash -z 0x1000 firmware.bin
+$ esptool.py --chip esp32 --port /dev/cuaU0 --baud 921600 write_flash -z 0x1000 bootloader.bin
 ```
 
 参数说明：
 
 - `-z`：压缩模式，速度更快。
-- `0x10000`：应用程序起始地址。
-- `firmware.bin`：要烧录的应用程序固件。
+- `0x1000`：应用程序起始地址。
+- `bootloader.bin`：要烧录的应用程序固件。
 
 额外说明：
 
@@ -424,6 +424,9 @@ $ esptool.py --chip esp32 --port /dev/cuaU0 --baud 921600 write_flash -z 0x1000 
 | partition table | `0x8000` |
 | app (factory) | `0x10000` |
 
+>**警告**
+>
+>不同型号的刷写地址不一定一致，请务必参考官方文档进行核查。参见：乐鑫科技. 获取不同软件开发平台的固件烧录信息（开发阶段）[EB/OL]. (n.d.)[2026-04-19]. <https://docs.espressif.com/projects/esp-techpedia/zh_CN/latest/esp-friends/get-started/try-firmware/get-firmware-address.html>.
 
 或者使用 idf.py 烧录：
 


### PR DESCRIPTION
## Summary by Sourcery

澄清 ESP32 刷写命令，并在嵌入式开发指南中记录不同型号芯片对刷写地址的要求。

Documentation:
- 修正用于刷写 ESP32 bootloader 的示例 `esptool.py` 刷写命令及其参数说明。
- 新增警告说明：不同芯片型号的刷写地址各不相同，并添加指向乐鑫官方文档的链接，以便核对固件地址。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify ESP32 flash command and document model-specific flash address requirements in the embedded development guide.

Documentation:
- Correct the example esptool.py flash command and parameter descriptions for ESP32 bootloader flashing.
- Add a warning that flash addresses vary by chip model and link to the official Espressif documentation for verifying firmware addresses.

</details>