### PR TITLE
增补伪终端

### DIFF
--- a/di-4-zhang-freebsd-ji-chu/di-4.4-jie-xu-ni-kong-zhi-tai-he-zhong-duan.md
+++ b/di-4-zhang-freebsd-ji-chu/di-4.4-jie-xu-ni-kong-zhi-tai-he-zhong-duan.md
@@ -113,7 +113,16 @@ ttyv8	"/usr/local/bin/xdm -nodaemon"	xterm	off secure
 
 >**技巧**
 >
->如果操作失误，但是配置了 SHHD 服务，仍可通过 SSH 远程链接 FreeBSD 系统。
+>如果操作失误，但是配置了 SHHD 服务，仍可通过 SSH 远程链接 FreeBSD 系统，将生成一个 pts(4) 伪终端 `/dev/pts/n`。
+>
+>```sh
+>$ w
+>10:22PM  up 27 mins, 3 users, load averages: 0.03, 0.04, 0.00
+>USER       TTY      FROM            LOGIN@  IDLE WHAT
+>ykla       pts/0    192.168.179.1   9:55PM     4 su (sh)
+>ykla       pts/1    192.168.179.1  10:22PM     - w
+>```
+
 
 注意，最后一个虚拟控制台（ttyv8）用于访问图形环境（如果已安装并配置了 Xorg）。
 


### PR DESCRIPTION
Added information about generating a pts pseudo-terminal when SSH is configured.

## Summary by Sourcery

Documentation:
- 记录 SSH 登录会创建 `/dev/pts/n` 伪终端，并展示通过 `w` 命令列出的会话示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document that SSH logins create `/dev/pts/n` pseudo-terminals and show a sample session listing via the `w` command.

</details>