### PR TITLE
不再维护其他 BSD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,11 +385,3 @@ $ git clone https://github.com/FreeBSD-Ask/FreeBSD-Ask
 **需要重写** 的内容（请撰写这些内容）：
 
 参见：Projects[EB/OL]. [2026-03-26]. <https://github.com/FreeBSD-Ask/FreeBSD-Ask/projects>。
-
-### NetBSD ToDo
-
-参见：Projects[EB/OL]. [2026-03-26]. <https://github.com/FreeBSD-Ask/FreeBSD-Ask/projects>。
-
-### DragonFlyBSD ToDo
-
-参见：Projects[EB/OL]. [2026-03-26]. <https://github.com/FreeBSD-Ask/FreeBSD-Ask/projects>。


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

文档：
- 从 CONTRIBUTING 中移除 NetBSD 和 DragonFlyBSD 的 TODO 小节，因为它们已不再维护。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Remove NetBSD and DragonFlyBSD TODO subsections from CONTRIBUTING as they are no longer maintained.

</details>