### PR TITLE
Revise DG2 Arc graphics card support details

### DIFF
--- a/di-7-zhang-x-window-xi-tong/di-7.1-jie-xian-ka-qu-dong-gai-shu.md
+++ b/di-7-zhang-x-window-xi-tong/di-7.1-jie-xian-ka-qu-dong-gai-shu.md
@@ -28,7 +28,7 @@ DRM 是 Linux 内核的子系统，负责与现代显卡的 GPU 交互。FreeBSD
 
 > **注意**
 >
-> DG2 Arc 显卡在DRM6.12从Linux移植完成后，可以在FreeBSD上使用并能过播放视频，参见：https://github.com/freebsd/drm-kmod/pull/427 
+> DG2 Arc 显卡在DRM6.12从Linux移植完成后，可以在FreeBSD上使用并能够播放视频，参见：https://github.com/freebsd/drm-kmod/pull/427 
 
 显卡支持情况：
 

--- a/di-7-zhang-x-window-xi-tong/di-7.1-jie-xian-ka-qu-dong-gai-shu.md
+++ b/di-7-zhang-x-window-xi-tong/di-7.1-jie-xian-ka-qu-dong-gai-shu.md
@@ -26,9 +26,9 @@ DRM 是 Linux 内核的子系统，负责与现代显卡的 GPU 交互。FreeBSD
 >
 > 这种移植并不覆盖 Linux 现有的全部 DRM GPU 驱动，目前仅包括 i915、amdgpu 和 radeon，vmwgfx、xe、virtio 等均未移植。这些未移植的 GPU 通常无法在 Wayland 上运行，只能使用 X11 显示协议。
 
-> **注意**
+> **技巧**
 >
-> DG2 Arc 显卡在DRM6.12从Linux移植完成后，可以在FreeBSD上使用并能够播放视频，参见：https://github.com/freebsd/drm-kmod/pull/427 
+> 自 DRM 6.12 起，DG2 Arc 显卡可以正常工作，参见：<https://github.com/freebsd/drm-kmod/pull/427>.
 
 显卡支持情况：
 

--- a/di-7-zhang-x-window-xi-tong/di-7.1-jie-xian-ka-qu-dong-gai-shu.md
+++ b/di-7-zhang-x-window-xi-tong/di-7.1-jie-xian-ka-qu-dong-gai-shu.md
@@ -28,7 +28,7 @@ DRM 是 Linux 内核的子系统，负责与现代显卡的 GPU 交互。FreeBSD
 
 > **注意**
 >
-> DG2 Arc 显卡尚不受支持（截至 DRM 6.1 版本），相关技术细节可参见：Intel Arc A770: Kernel panic on kldload i915kms.ko #315[EB/OL]. [2026-03-26]. <https://github.com/freebsd/drm-kmod/issues/315>。可能需要等到 6.12 的移植才能提供支持。
+> DG2 Arc 显卡在DRM6.12从Linux移植完成后，可以在FreeBSD上使用并能过播放视频，参见：https://github.com/freebsd/drm-kmod/pull/427 
 
 显卡支持情况：
 


### PR DESCRIPTION
Updated DG2 Arc graphics card support information and reference link.

## Summary by Sourcery

Documentation:
- 修改 DG2 Arc 显卡支持说明，指出在 DRM 6.12 移植到 FreeBSD 后将可用，并提供更新后的参考链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Revise DG2 Arc graphics card support note to indicate availability on FreeBSD after DRM 6.12 is ported and provide an updated reference link.

</details>