### PR TITLE
Update di-7.1-jie-xian-ka-qu-dong-gai-shu.md

### DIFF
--- a/di-7-zhang-x-window-xi-tong/di-7.1-jie-xian-ka-qu-dong-gai-shu.md
+++ b/di-7-zhang-x-window-xi-tong/di-7.1-jie-xian-ka-qu-dong-gai-shu.md
@@ -28,7 +28,7 @@ DRM 是 Linux 内核的子系统，负责与现代显卡的 GPU 交互。FreeBSD
 
 > **技巧**
 >
-> Arc DG2 显卡最迟自 DRM 6.12 起可正常工作，参见：<https://github.com/freebsd/drm-kmod/pull/427>.
+> Arc DG2 显卡最迟自 DRM 6.9 起可正常工作.
 
 显卡支持情况：
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 更新 X Window 系统文档，将 Arc DG2 GPU 的支持最低版本从 DRM 6.12 更正为 DRM 6.9。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the X Window system documentation to state that Arc DG2 GPUs work starting from DRM 6.9 instead of 6.12.

</details>