### PR TITLE
Update acknowledgments with archived blog link

### DIFF
--- a/qian-yan/zhi-xie.md
+++ b/qian-yan/zhi-xie.md
@@ -2,7 +2,7 @@
 
 ## 文献来源与基础架构
 
-本书初版架构基于 Smile_Zheng. 操作系统笔记[EB/OL]. 百度贴吧. [2026-04-04]. <https://tieba.baidu.com/p/7424071955>. 主要引用了防火墙章节、用户与权限章节。原笔记主要转引了《FreeBSD 技术内幕》（Tiemann B, Urban M. FreeBSD 技术内幕（FreeBSD Unleashed）[M]. 智慧东方工作室，译. 北京：机械工业出版社，2002.），以及参考了 [🎀🌸 星不萌 🌸🎀](https://tieba.baidu.com/home/main?un=%E6%98%9F%E5%85%89Re) 的博客文章。
+本书初版架构基于 Smile_Zheng. 操作系统笔记[EB/OL]. 百度贴吧. [2026-04-04]. <https://tieba.baidu.com/p/7424071955>. 主要引用了防火墙章节、用户与权限章节。原笔记主要转引了《FreeBSD 技术内幕》（Tiemann B, Urban M. FreeBSD 技术内幕（FreeBSD Unleashed）[M]. 智慧东方工作室，译. 北京：机械工业出版社，2002.），以及参考了 [🎀🌸 星不萌 🌸🎀](https://tieba.baidu.com/home/main?un=%E6%98%9F%E5%85%89Re) 的博客文章（[互联网档案馆存档](https://web.archive.org/web/20201128071425/https://www.moebsd.cn/)）。
 
 在本书第三版中，我们援引 FreeBSD 文档项目的内容，增补了理论、命令选项和历史部分。许可证参见 **COPYRIGHT** 文件。
 


### PR DESCRIPTION
Added an archived link to the original blog article in the acknowledgments section.

## Summary by Sourcery

Documentation:
- 在致谢部分为引用的博客文章添加一个 Internet Archive 链接，以便保留对原始来源的访问。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add an Internet Archive link for the referenced blog post in the acknowledgments section to preserve access to the original source.

</details>