### PR TITLE
Fix HFS+ partition device name in documentation

### DIFF
--- a/di-16-zhang-cun-chu-yu-wen-jian-xi-tong-guan-li/di-16.5-jie-macos-wen-jian-xi-tong.md
+++ b/di-16-zhang-cun-chu-yu-wen-jian-xi-tong-guan-li/di-16.5-jie-macos-wen-jian-xi-tong.md
@@ -73,7 +73,7 @@ Apple 文件系统（APFS）是 Apple 开发的新一代文件系统，自 macOS
 >
 > 当前 `libfsapfs` 主要提供只读支持，无法进行写入操作。
 
-## HFS+ 文件系统
+## HFS/HFS+ 文件系统
 
 HFS/HFS+ 是 macOS 在 APFS 问世前的主要文件系统，常见于较旧的 Mac 设备和外部驱动器。FreeBSD 通过 filesystems/hfsfuse 软件包提供了对 HFS/HFS+ 的只读支持。
 
@@ -119,7 +119,7 @@ HFS/HFS+ 是 macOS 在 APFS 问世前的主要文件系统，常见于较旧的 
 
 ### 挂载 HFS/HFS+ 卷
 
-通过指定其 FreeBSD 分区名和挂载点（要求已存在）来挂载 HFS/HFS+ 卷。以下示例将 **/dev/ada1** 挂载到 **/mnt**：
+通过指定其 FreeBSD 分区名和挂载点（要求已存在）来挂载 HFS/HFS+ 卷。以下示例将 **/dev/ada0** 挂载到 **/mnt**：
 
 ```sh
 # hfsfuse /dev/ada0 /mnt


### PR DESCRIPTION
## Summary by Sourcery

更新 macOS 文件系统文档，以正确描述 HFS/HFS+，并修正一个 HFS/HFS+ 挂载命令示例。

文档：
- 明确章节标题，使其涵盖 HFS 和 HFS+ 两种文件系统。
- 更正挂载命令中使用的 HFS/HFS+ 设备名称示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS filesystem documentation to correctly describe HFS/HFS+ and fix an HFS/HFS+ mount command example.

Documentation:
- Clarify the section heading to cover both HFS and HFS+ filesystems.
- Correct the example HFS/HFS+ device name used in the mount command.

</details>