### PR TITLE
更新 Archlinux 兼容层（约 30%）

### DIFF
--- a/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.3-jie-ubuntu-debian-jian-rong-ceng.md
+++ b/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.3-jie-ubuntu-debian-jian-rong-ceng.md
@@ -55,6 +55,12 @@
 # sysctl compat.linux.osrelease=6.16.2                      # 立即设置 Linux 兼容层内核版本，便于当前会话继续使用
 ```
 
+重启 Linux 兼容层服务：
+
+```sh
+service linux start
+```
+
 ### 进入 Ubuntu 兼容层
 
 完成文件系统挂载和内核版本设定后，进入 Ubuntu 兼容层继续配置。

--- a/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.4-jie-arch-linux-jian-rong-ceng.md
+++ b/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.4-jie-arch-linux-jian-rong-ceng.md
@@ -188,8 +188,6 @@ Server = https://mirrors.tuna.tsinghua.edu.cn/archlinuxcn/$arch
 # locale-gen
 ```
 
-编辑 ``
-
 ## shell 脚本
 
 脚本内容如下：

--- a/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.4-jie-arch-linux-jian-rong-ceng.md
+++ b/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.4-jie-arch-linux-jian-rong-ceng.md
@@ -1,10 +1,6 @@
 # 13.4 Arch Linux 兼容层
 
-Arch Linux 兼容层基于 Arch bootstrap 镜像构建。Bash/Zsh 在 chroot 后无终端输出（termios2 ioctls 未实现，FreeBSD 15-STABLE 已修复）。
-
-> **注意**
->
-> 完成兼容层构建并 chroot 进入环境后，终端界面可能表现为无响应；Bash 进程虽未产生输出，但仍可正常接收输入并执行命令。即使将默认 shell 切换至 Zsh，该现象仍然存在，且 TTY 终端会报告错误：`linux: jid 0 pid 1154 (bash): linux_ioctl_fallback fd=0, cmd=0x802c542a ('T',42) is not implemented`。根据 FreeBSD 源代码仓库中的提交记录 [linux: support termios2 ioctls](https://github.com/freebsd/freebsd-src/pull/1949)，该问题已在 FreeBSD 15.0-STABLE 中修复。
+Arch Linux 兼容层基于 Arch bootstrap 镜像构建。
 
 视频教程：[07-FreeBSD-Arch Linux 兼容层脚本使用说明](https://www.bilibili.com/video/BV1wg4y1w7QV)
 
@@ -45,9 +41,9 @@ Arch Linux 兼容层基于 Arch bootstrap 镜像构建。Bash/Zsh 在 chroot 后
 
 ### 调整 Linux 兼容层默认内核版本
 
-对于滚动发行版，Linux 兼容层的默认内核版本通常较低。如果直接构建，Arch Linux 兼容层在 chroot 时会报错 `FATAL: kernel too old`。因此，需要将 Linux 兼容层的内核版本调整为 6.12.63（或其他较高版本）。
+对于滚动发行版，Linux 兼容层的默认内核版本通常较低。如果直接构建，Arch Linux 兼容层在 chroot 时会报错 `FATAL: kernel too old`。因此，需要将 Linux 兼容层中宣称的 Linux 内核版本调整为较高版本（如 6.12.63）。
 
-- 查看当前 Linux 兼容层的内核版本：
+查看当前 Linux 兼容层的内核版本：
 
 ```sh
 # sysctl compat.linux.osrelease
@@ -58,11 +54,37 @@ compat.linux.osrelease: 5.15.0
 >
 > 必须先启动 `linux` 服务才能查看当前的 Linux 内核版本。
 
-- 调整到较新的版本号（参见：Kernel.org. The Linux Kernel Archives[EB/OL]. [2026-03-26]. <https://www.kernel.org/>. 可获得所需版本号）：
+调整到较新的版本号：
 
 ```sh
-# echo "compat.linux.osrelease=6.12.63" >> /etc/sysctl.conf   # 将 Linux 兼容内核版本写入 sysctl 配置文件，实现持久化
-# sysctl compat.linux.osrelease=6.12.63                      # 立即生效设置，无需重启
+# echo "compat.linux.osrelease=6.12.63" >> /etc/sysctl.conf # 将 Linux 兼容内核版本写入 sysctl 配置文件，实现持久化
+# sysctl compat.linux.osrelease=6.12.63 # 立即生效设置，无需重启
+```
+
+#### 参考文献
+
+- Kernel.org. The Linux Kernel Archives[EB/OL]. [2026-03-26]. <https://www.kernel.org/>. 参见此条目可获得所需 Linux 内核版本号
+
+## 挂载文件系统
+
+还需要挂载必要的文件系统。将 Linux 兼容层默认路径指向 **/compat/arch** 以实现相关文件系统的自动挂载。
+
+立刻生效：
+
+```sh
+# sysctl compat.linux.emul_path=/compat/arch
+```
+
+永久设置：
+
+```sh
+# echo "compat.linux.emul_path=/compat/arch" >> /etc/sysctl.conf
+```
+
+重启 Linux 兼容层服务：
+
+```sh
+service linux start
 ```
 
 ### 安装自举系统
@@ -75,46 +97,6 @@ compat.linux.osrelease: 5.15.0
 
 `--strip-components=1` 即在解压 `archlinux-bootstrap-x86_64.tar.zst` 文件时去掉外层路径 `root.x86_64`，直接解压到指定路径。
 
-## 挂载文件系统
-
-将 `nullfs_load="YES"` 写入 **/boot/loader.conf** 文件（如需立刻生效，可使用 `kldload nullfs`）。
-
-将以下内容添加到 **/etc/fstab** 文件中：
-
-```sh
-devfs           /compat/arch/dev      devfs           rw,late                      0       0
-tmpfs           /compat/arch/dev/shm  tmpfs           rw,late,size=1g,mode=1777    0       0
-fdescfs         /compat/arch/dev/fd   fdescfs         rw,late,linrdlnk             0       0
-linprocfs       /compat/arch/proc     linprocfs       rw,late                      0       0
-linsysfs        /compat/arch/sys      linsysfs        rw,late                      0       0
-/tmp            /compat/arch/tmp      nullfs          rw,late                      0       0
-```
-
-加入后的 **/etc/fstab** 文件示例（**请勿复制粘贴下方代码**）：
-
-```sh
-# Device                Mountpoint      FStype  Options         Dump    Pass#
-/dev/gpt/efiboot0               /boot/efi       msdosfs rw              2       2
-/dev/nda0p2             none    swap    sw              0       0
-devfs           /compat/arch/dev      devfs           rw,late                      0       0
-tmpfs           /compat/arch/dev/shm  tmpfs           rw,late,size=1g,mode=1777    0       0
-fdescfs         /compat/arch/dev/fd   fdescfs         rw,late,linrdlnk             0       0
-linprocfs       /compat/arch/proc     linprocfs       rw,late                      0       0
-linsysfs        /compat/arch/sys      linsysfs        rw,late                      0       0
-/tmp            /compat/arch/tmp      nullfs          rw,late                      0       0
-```
-
-> **警告**
->
-> 请严格遵照上面的操作，否则需进入急救模式！
-
-检查挂载过程中是否有报错：
-
-```sh
-# mount -al
-```
-
-挂载 **/etc/fstab** 文件中所有未挂载的文件系统。
 
 ## 基本配置
 
@@ -231,162 +213,190 @@ yay 及其他 AUR 助手禁止以 root 身份直接运行，需要在 chroot 中
 脚本内容如下：
 
 ```sh
-#!/bin/sh                                                 # 指定脚本使用的 shell
+#!/bin/sh
 
-rootdir=/compat/arch                                     # 定义 Arch 兼容层根目录
-url="https://ftp.sjtu.edu.cn/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst"  # Arch Linux bootstrap 下载地址
+BASE_URL="https://ftp.sjtu.edu.cn/archlinux/iso/latest"
+rootdir=/compat/arch
 
-echo "Starting Arch Linux installation..."                   # 输出安装开始信息
-echo "Checking required modules..."                                 # 输出模块检查信息
+url="${BASE_URL}/archlinux-bootstrap-x86_64.tar.zst"
+BOOTSTRAP=archlinux-bootstrap-x86_64.tar.zst
+SHAFILE="${BASE_URL}/sha256sums.txt"
 
-# 检查 linux 模块
-if [ "$(sysrc -n linux_enable)" = "NO" ]; then          # 检查 Linux 内核模块是否启用
-        echo "The Linux module is not enabled. Enable it now? (Y|n)"  # 提示是否继续
-        read answer                                     # 读取用户输入
-        case $answer in                                 # 处理用户选择
-                [Nn][Oo]|[Nn])
-                        echo "Linux module not enabled" # 提示模块未加载
-                        exit 1                         # 退出脚本
-                        ;;
-                [Yy][Ee][Ss]|[Yy]|"")
-                        sysrc linux_enable=YES         # 启用 Linux 内核模块
-                        ;;
-        esac
+LinuxKernel=7.0.11
+
+echo "Starting Arch Linux installation..."
+
+echo "Checking required modules..."
+
+# linux compat
+if [ "$(sysrc -n linux_enable)" = "NO" ]; then
+    echo "Linux module is not enabled. Enable it now? (Y|n)"
+    read answer
+    case $answer in
+        [Nn][Oo]|[Nn])
+            echo "Linux module not enabled"
+            exit 1
+            ;;
+        *)
+            service linux enable
+            ;;
+    esac
 fi
-echo "Starting Linux service"                                       # 输出启动 Linux 信息
-service linux start                                      # 启动 Linux 内核模块
 
-# 检查 dbus
-if ! /usr/bin/which -s dbus-daemon;then                 # 检查 dbus-daemon 是否存在
-        echo "dbus-daemon not found. Install D-Bus? [Y|n]"  # 提示安装 dbus
-        read  answer                                    # 读取用户输入
-        case $answer in
-            [Nn][Oo]|[Nn])
-                echo "D-Bus not installed"               # 提示未安装 dbus
-                exit 2                                  # 退出脚本
-                ;;
-            [Yy][Ee][Ss]|[Yy]|"")
-                pkg install -y dbus                     # 安装 dbus
-                ;;
-        esac
+service linux start
+
+# emulation path
+sysctl compat.linux.emul_path="${rootdir}"
+
+if ! grep -q '^compat.linux.emul_path=' /etc/sysctl.conf 2>/dev/null; then
+    echo "compat.linux.emul_path=${rootdir}" >> /etc/sysctl.conf
+else
+    sed -i '' "s|^compat.linux.emul_path=.*|compat.linux.emul_path=${rootdir}|" /etc/sysctl.conf
+fi
+
+echo "compat.linux.emul_path=$(sysctl -n compat.linux.emul_path)"
+
+echo "compat.linux.osrelease=${LinuxKernel}"
+sysctl compat.linux.osrelease=${LinuxKernel}
+
+if ! grep -q '^compat.linux.osrelease=' /etc/sysctl.conf 2>/dev/null; then
+    echo "compat.linux.osrelease=${LinuxKernel}" >> /etc/sysctl.conf
+else
+    sed -i '' "s|^compat.linux.osrelease=.*|compat.linux.osrelease=${LinuxKernel}|" /etc/sysctl.conf
+fi
+
+service linux restart
+
+# dbus
+if ! command -v dbus-daemon >/dev/null 2>&1; then
+    echo "dbus-daemon not found. Install D-Bus? [Y|n]"
+    read answer
+    case $answer in
+        [Nn][Oo]|[Nn])
+            exit 2
+            ;;
+        *)
+            pkg install -y dbus
+            ;;
+    esac
+fi
+
+if [ "$(sysrc -n dbus_enable)" != "YES" ]; then
+    echo "Enable D-Bus now? (Y|n)"
+    read answer
+    case $answer in
+        [Nn][Oo]|[Nn])
+            exit 2
+            ;;
+        *)
+            service dbus enable
+            ;;
+    esac
+fi
+
+service dbus start
+
+# bootstrap + checksum + resume + retry
+echo "Downloading bootstrap..."
+
+fetch -r -o "${BOOTSTRAP}" "${url}"
+
+[ -f sha256sums.txt ] || fetch -o sha256sums.txt "${SHAFILE}"
+
+verify_checksum() {
+    EXPECTED=$(awk "/${BOOTSTRAP}/{print \$1}" sha256sums.txt)
+    ACTUAL=$(sha256 -q "${BOOTSTRAP}")
+
+    echo "File: ${BOOTSTRAP}"
+    echo "Expected SHA256: ${EXPECTED}"
+    echo "Actual SHA256:   ${ACTUAL}"
+
+    if [ -z "$EXPECTED" ]; then
+        echo "Checksum not found in sha256sums.txt"
+        return 1
     fi
 
-if [ "$(sysrc -n dbus_enable)" != "YES" ]; then         # 检查 dbus 服务是否启用
-        echo "D-Bus is not enabled. Enable it now? (Y|n)"  # 提示是否启用
-        read answer                                     # 读取用户输入
-        case $answer in
-            [Nn][Oo]|[Nn])
-                        echo "D-Bus not enabled"        # 提示 dbus 未运行
-                        exit 2                          # 退出脚本
-                        ;;
-            [Yy][Ee][Ss]|[Yy]|"")
-                        service dbus enable             # 启用 dbus 服务开机自启
-                        ;;
-        esac
-fi
-echo "Starting D-Bus service"                                        # 输出启动 dbus 信息
-service dbus start                                       # 启动 dbus 服务
+    if [ "$EXPECTED" != "$ACTUAL" ]; then
+        return 1
+    fi
 
-echo "Now bootstrapping Arch Linux"                  # 输出 bootstrap 开始信息
+    return 0
+}
 
-fetch ${url}                                             # 下载 Arch Linux bootstrap 压缩包
-mkdir -p ${rootdir}                                           # 创建挂载目录
-tar --use-compress-program=unzstd -xpvf archlinux-bootstrap-x86_64.tar.zst --strip-components=1 -C ${rootdir} --numeric-owner  # 解压压缩包
-rm archlinux-bootstrap-x86_64.tar.zst                  # 删除压缩包
+echo "Verifying checksum..."
 
-if [ ! "$(sysrc -f /boot/loader.conf -qn nullfs_load)" = "YES" ]; then  # 检查 nullfs 是否加载
-        echo "nullfs_load should be set to YES. Continue? (Y|n)"  # 提示是否继续
-        read answer                                     # 读取用户输入
-        case $answer in
-            [Nn][Oo]|[Nn])
-                echo "nullfs is not loaded"                  # 提示未加载
-		exit 3                                      # 退出脚本
-                ;;
-            [Yy][Ee][Ss]|[Yy]|"")
-                sysrc -f /boot/loader.conf nullfs_load=yes  # 设置 nullfs 开机自启
-                ;;
-        esac
+if ! verify_checksum; then
+    echo "First verification failed. Removing file and retrying..."
+
+    rm -f "${BOOTSTRAP}"
+
+    echo "Redownloading bootstrap..."
+    fetch -r -o "${BOOTSTRAP}" "${url}"
+
+    echo "Re-verifying checksum..."
+
+    if ! verify_checksum; then
+        echo "Checksum failed after retry."
+        exit 1
+    fi
 fi
 
-if ! kldstat -n nullfs >/dev/null 2>&1;then            # 检查 nullfs 模块是否已加载
-        echo "Loading nullfs module"                      # 输出加载信息
-        kldload -v nullfs                               # 加载 nullfs 模块
-fi
+echo "Checksum OK"
+rm -f sha256sums.txt
 
-echo "Mounting required file systems for Linux"                         # 输出挂载文件系统信息
-echo "devfs ${rootdir}/dev devfs rw,late 0 0" >> /etc/fstab        # devfs 挂载
-echo "tmpfs ${rootdir}/dev/shm tmpfs rw,late,size=1g,mode=1777 0 0" >> /etc/fstab  # tmpfs 挂载
-echo "fdescfs ${rootdir}/dev/fd fdescfs rw,late,linrdlnk 0 0" >> /etc/fstab        # fdescfs 挂载
-echo "linprocfs ${rootdir}/proc linprocfs rw,late 0 0" >> /etc/fstab               # linprocfs 挂载
-echo "linsysfs ${rootdir}/sys linsysfs rw,late 0 0" >> /etc/fstab                  # linsysfs 挂载
-echo "/tmp ${rootdir}/tmp nullfs rw,late 0 0" >> /etc/fstab                         # /tmp 挂载
-#echo "/home ${rootdir}/home nullfs rw,late 0 0" >> /etc/fstab                     # /home 挂载，可选
-mount -al                                               # 挂载 fstab 中所有文件系统
+mkdir -p "${rootdir}"
 
-echo "compat.linux.osrelease needs to be changed for Arch Linux. Continue? (Y|n)"  # 提示修改 Linux 内核版本
-read answer                                             # 读取用户输入
+tar -I unzstd -xpf "${BOOTSTRAP}" -C "${rootdir}" --strip-components=1 --numeric-owner
+rm -f "${BOOTSTRAP}"
+
+echo "Basic system ready."
+echo "chroot ${rootdir} /bin/bash"
+
+# initial config
+echo "Continue initial Arch setup? [Y|n]"
+read answer
 case $answer in
-	[Nn][Oo]|[Nn])
-		echo "Almost done, but this step is required"                        # 提示跳过修改
-		exit 4
-		;;
-	[Yy][Ee][Ss]|[Yy]|"")
-		echo "compat.linux.osrelease=6.12.63" >> /etc/sysctl.conf  # 持久化设置 Linux 内核版本
-		sysctl compat.linux.osrelease=6.12.63                     # 立即生效
-                ;;
+    [Nn][Oo]|[Nn])
+        exit 0
+        ;;
 esac
-echo "Basic system ready."                                        # 提示基本系统安装完成
-echo "To enter: chroot ${rootdir} /bin/bash"             # 提示使用 chroot 进入 Arch 兼容层
-echo ""
-echo "The following initial configuration will be performed:"
-echo "  - Set resolv.conf to Alibaba DNS"
-echo "  - Initialize pacman keyring"
-echo "  - Configure Tsinghua mirror"
-echo "  - Add Arch Linux CN repository"
-echo "Continue? [Y|n]"
-read answer                                             # 读取用户输入
-case $answer in
-	[Nn][Oo]|[Nn])
-		echo "Please configure Arch Linux manually. Exiting."   # 提示用户自行配置
-		exit 0
-		;;
-	[Yy][Ee][Ss]|[Yy]|"")
-		echo "nameserver 223.5.5.5" >> ${rootdir}/etc/resolv.conf    # 设置 DNS
-		echo "Initializing pacman keyring"
-		chroot ${rootdir} /bin/bash -c "pacman-key --init"           # 初始化 pacman 密钥
-		echo "Importing Arch Linux signing keys"
-		chroot ${rootdir} /bin/bash -c "pacman-key --populate archlinux"  # 导入官方密钥
-		echo "Configuring Tsinghua mirror"
-		cat ${rootdir}/etc/pacman.d/mirrorlist > mlst.tmp             # 备份镜像列表
-		echo 'Server = https://mirrors.tuna.tsinghua.edu.cn/archlinux/$repo/os/$arch' > ${rootdir}/etc/pacman.d/mirrorlist  # 设置清华镜像
-		cat mlst.tmp >> ${rootdir}/etc/pacman.d/mirrorlist            # 恢复原有镜像列表内容
-		rm mlst.tmp                                                    # 删除临时文件
-		echo "Adding Arch Linux CN repository"
-		echo '[archlinuxcn]' >> ${rootdir}/etc/pacman.conf             # 添加 archlinuxcn 仓库
-		echo 'Server = https://mirrors.tuna.tsinghua.edu.cn/archlinuxcn/$arch' >> ${rootdir}/etc/pacman.conf  # 设置 archlinuxcn 镜像
-		echo "Refreshing package sources and system"                              # 输出刷新信息
-		echo "Enabling DisableSandbox for pacman (required to avoid the error: restricting filesystem access failed because landlock is not supported by the kernel)"  # 提示禁用 Sandbox
-		sed -E -i '' 's/^[[:space:]]*#[[:space:]]*DisableSandbox/DisableSandbox/' ${rootdir}/etc/pacman.conf  # 取消注释 DisableSandbox
-		grep -n 'DisableSandbox' ${rootdir}/etc/pacman.conf           # 验证 DisableSandbox
-		chroot ${rootdir} /bin/bash -c "pacman -Syyu --noconfirm"     # 更新系统
-		echo "Refreshing keyring"                                             # 输出刷新密钥信息
-    		chroot ${rootdir} /bin/bash -c "pacman -S --noconfirm archlinuxcn-keyring"  # 安装 archlinuxcn-keyring
-		echo "Installing yay"                                             # 输出安装 yay 信息
-		chroot ${rootdir} /bin/bash -c "pacman -S --noconfirm yay base base-devel nano wqy-zenhei"  # 安装软件
-		echo "Creating user test"                                             # 输出创建用户信息
-		chroot ${rootdir} /bin/bash -c "useradd -G wheel -m test"      # 创建用户 test 并加入 wheel 组
-		echo "Modifying sudoers configuration"                       # 输出修改 sudoers 信息
-		echo '%wheel ALL=(ALL) ALL' >> ${rootdir}/etc/sudoers          # 允许 wheel 组 sudo 权限
-		echo '%sudo ALL=(ALL:ALL) ALL' >> ${rootdir}/etc/sudoers       # 允许 sudo 组 sudo 权限
-		echo "Replacing fakeroot with fakeroot-tcp"                                         # 输出安装 fakeroot-tcp 信息
-		chroot ${rootdir} /bin/bash -c "pacman -S --noconfirm fakeroot-tcp"  # 安装 fakeroot-tcp
-		echo "Configuring locale settings"                                  # 输出本地化设置信息
-		echo 'zh_CN.UTF-8 UTF-8' >> ${rootdir}/etc/locale.gen           # 添加中文 UTF-8
-		chroot ${rootdir} /bin/bash -c "locale-gen"                     # 生成语言环境
-		echo "All done."                                                # 输出完成信息
-                ;;
-esac
-echo "Now you can run '# chroot /compat/arch/ /bin/bash' to enter Arch Linux"   # 提示用户进入 Arch Linux
+
+grep -q "nameserver 223.5.5.5" "${rootdir}/etc/resolv.conf" 2>/dev/null || \
+    echo "nameserver 223.5.5.5" >> "${rootdir}/etc/resolv.conf"
+
+chroot "${rootdir}" /bin/bash -c "pacman-key --init"
+chroot "${rootdir}" /bin/bash -c "pacman-key --populate archlinux"
+
+cp "${rootdir}/etc/pacman.d/mirrorlist" "${rootdir}/etc/pacman.d/mirrorlist.bak"
+
+{
+    echo 'Server = https://mirrors.tuna.tsinghua.edu.cn/archlinux/\$repo/os/\$arch'
+    cat "${rootdir}/etc/pacman.d/mirrorlist.bak"
+} > "${rootdir}/etc/pacman.d/mirrorlist"
+
+rm -f "${rootdir}/etc/pacman.d/mirrorlist.bak"
+
+echo '[archlinuxcn]' >> "${rootdir}/etc/pacman.conf"
+echo 'Server = https://mirrors.tuna.tsinghua.edu.cn/archlinuxcn/$arch' >> "${rootdir}/etc/pacman.conf"
+
+sed -i '' 's/^[#[:space:]]*DisableSandbox/DisableSandbox/' "${rootdir}/etc/pacman.conf"
+
+chroot "${rootdir}" /bin/bash -c "pacman -Syyu --noconfirm"
+chroot "${rootdir}" /bin/bash -c "pacman -S --noconfirm archlinuxcn-keyring"
+
+chroot "${rootdir}" /bin/bash -c "pacman -S --noconfirm yay base base-devel nano wqy-zenhei"
+
+useradd -G wheel -m test
+
+echo '%wheel ALL=(ALL) ALL' >> "${rootdir}/etc/sudoers"
+echo '%sudo ALL=(ALL:ALL) ALL' >> "${rootdir}/etc/sudoers"
+
+chroot "${rootdir}" /bin/bash -c "pacman -S --noconfirm fakeroot-tcp"
+
+echo 'zh_CN.UTF-8 UTF-8' >> "${rootdir}/etc/locale.gen"
+chroot "${rootdir}" /bin/bash -c "locale-gen"
+
+echo "Done."
 ```
 
 ## 参考文献

--- a/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.4-jie-arch-linux-jian-rong-ceng.md
+++ b/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.4-jie-arch-linux-jian-rong-ceng.md
@@ -166,33 +166,13 @@ Server = https://mirrors.tuna.tsinghua.edu.cn/archlinuxcn/$arch
 >
 > 在 `==> Locally signing trusted keys in keyring...` 这一步可能需要十分钟或更长时间。请耐心等待。
 
-yay 及其他 AUR 助手禁止以 root 身份直接运行，需要在 chroot 中创建一个具备普通权限的新用户（经测试，FreeBSD 中现有普通用户不适用于此场景）。
-
-创建用户 test，并加入 wheel 组，同时创建用户主目录：
-
-```sh
-# useradd -G wheel -m test
-```
-
-使用文本编辑器编辑 sudoers 文件 **/etc/sudoers**，配置用户权限（如果有红色警告请忽略）：
-
-删除 `# %wheel ALL=(ALL) ALL` 前的注释符号 `#`。
-
-删除 `# %sudo ALL=(ALL:ALL) ALL` 前的注释符号 `#`。
-
-卸载 fakeroot 并安装 fakeroot-tcp，否则无法使用 AUR。
-
-该 bug 见 [Problem with fakeroot and qemu](https://archlinuxarm.org/forum/viewtopic.php?t=14466)。
+此外还需要卸载 fakeroot 并安装 fakeroot-tcp，否则无法使用 AUR。该 bug 见 [Problem with fakeroot and qemu](https://archlinuxarm.org/forum/viewtopic.php?t=14466)。
 
 使用 pacman 安装 fakeroot-tcp 工具：
 
 ```sh
 # pacman -S fakeroot-tcp # 会询问是否卸载 fakeroot，请确认并卸载。
 ```
-
-> **技巧**
->
-> 如果为用户 `test` 设置了密码后仍提示密码错误，需打开新终端，执行 `reboot` 命令重启 FreeBSD，随后继续操作。
 
 ### 区域设置
 
@@ -207,6 +187,8 @@ yay 及其他 AUR 助手禁止以 root 身份直接运行，需要在 chroot 中
 ```sh
 # locale-gen
 ```
+
+编辑 ``
 
 ## shell 脚本
 
@@ -346,11 +328,9 @@ rm -f sha256sums.txt
 
 mkdir -p "${rootdir}"
 
-tar -I unzstd -xpf "${BOOTSTRAP}" -C "${rootdir}" --strip-components=1 --numeric-owner
+tar --use-compress-program=unzstd -xpvf "${BOOTSTRAP}" --strip-components=1 -C "${rootdir}" --numeric-owner 2>&1 | grep -v "Error exit delayed from previous errors"
+ 
 rm -f "${BOOTSTRAP}"
-
-echo "Basic system ready."
-echo "chroot ${rootdir} /bin/bash"
 
 # initial config
 echo "Continue initial Arch setup? [Y|n]"
@@ -370,33 +350,39 @@ chroot "${rootdir}" /bin/bash -c "pacman-key --populate archlinux"
 cp "${rootdir}/etc/pacman.d/mirrorlist" "${rootdir}/etc/pacman.d/mirrorlist.bak"
 
 {
-    echo 'Server = https://mirrors.tuna.tsinghua.edu.cn/archlinux/\$repo/os/\$arch'
+    echo 'Server = https://mirrors.cernet.edu.cn/archlinux/$repo/os/$arch'
     cat "${rootdir}/etc/pacman.d/mirrorlist.bak"
 } > "${rootdir}/etc/pacman.d/mirrorlist"
 
 rm -f "${rootdir}/etc/pacman.d/mirrorlist.bak"
 
 echo '[archlinuxcn]' >> "${rootdir}/etc/pacman.conf"
-echo 'Server = https://mirrors.tuna.tsinghua.edu.cn/archlinuxcn/$arch' >> "${rootdir}/etc/pacman.conf"
+echo 'Server = https://mirrors.ustc.edu.cn/archlinuxcn/$arch' >> "${rootdir}/etc/pacman.conf"
+
+echo '[arch4edu]' >> "${rootdir}/etc/pacman.conf"
+echo 'SigLevel = Never' >> "${rootdir}/etc/pacman.conf"
+echo 'Server = https://mirrors.tuna.tsinghua.edu.cn/arch4edu/$arch' >> "${rootdir}/etc/pacman.conf"
+chroot "${rootdir}" /bin/bash -c "useradd -G wheel -m ykla"
+echo 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' >> "${rootdir}/etc/sudoers"
+chroot "${rootdir}" /bin/bash -c "mv /usr/share/libalpm/hooks/21-systemd-tmpfiles.hook    /usr/share/libalpm/hooks/21-systemd-tmpfiles.hook.disabled"
 
 sed -i '' 's/^[#[:space:]]*DisableSandbox/DisableSandbox/' "${rootdir}/etc/pacman.conf"
 
 chroot "${rootdir}" /bin/bash -c "pacman -Syyu --noconfirm"
 chroot "${rootdir}" /bin/bash -c "pacman -S --noconfirm archlinuxcn-keyring"
 
+
 chroot "${rootdir}" /bin/bash -c "pacman -S --noconfirm yay base base-devel nano wqy-zenhei"
 
-useradd -G wheel -m test
+chroot "${rootdir}" /bin/bash -c "pacman -Syu libunwind libedit --noconfirm --overwrite '*'"
 
-echo '%wheel ALL=(ALL) ALL' >> "${rootdir}/etc/sudoers"
-echo '%sudo ALL=(ALL:ALL) ALL' >> "${rootdir}/etc/sudoers"
-
-chroot "${rootdir}" /bin/bash -c "pacman -S --noconfirm fakeroot-tcp"
+chroot "${rootdir}" /bin/bash -c "pacman -Rdd fakeroot --noconfirm && pacman -S --noconfirm fakeroot-tcp"
 
 echo 'zh_CN.UTF-8 UTF-8' >> "${rootdir}/etc/locale.gen"
 chroot "${rootdir}" /bin/bash -c "locale-gen"
 
-echo "Done."
+echo "Base System ready."
+echo "chroot ${rootdir} /bin/bash"
 ```
 
 ## 参考文献

--- a/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.8-jie-qq-linux-ban.md
+++ b/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.8-jie-qq-linux-ban.md
@@ -130,12 +130,14 @@ $ exit # 切换回 root
 启动 QQ 客户端，禁用沙盒并启用进程内 GPU：
 
 ```sh
-# /opt/QQ/qq --no-sandbox --in-process-gpu  # 此时位于 Arch 兼容层！
+# /opt/QQ/qq --no-sandbox --in-process-gpu # 此时位于 Arch 兼容层！
 ```
+
+不支持 IPv6。
 
 > **注意**
 >
-> 如果以普通用户运行 QQ 时报错找不到 X11，请检查 `DISPLAY` 环境变量是否正确设置，并确保 X11 套接字（**/tmp/.X11-unix/**）对普通用户可访问。可尝试运行 `xhost +local:` 命令放宽权限。不建议以 root 权限运行 QQ，否则将无法使用输入法。
+> 如果以普通用户运行 QQ 时报错找不到 X11，请检查 `DISPLAY` 环境变量是否正确设置，并确保 X11 套接字（**/tmp/.X11-unix/**）对普通用户可访问。可尝试运行 `xhost +local:` 命令放宽权限。
 
 ![FreeBSD QQ](../.gitbook/assets/rlqq3.png)
 

--- a/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.8-jie-qq-linux-ban.md
+++ b/di-13-zhang-linux-er-jin-zhi-jian-rong-ceng/di-13.8-jie-qq-linux-ban.md
@@ -133,8 +133,6 @@ $ exit # 切换回 root
 # /opt/QQ/qq --no-sandbox --in-process-gpu # 此时位于 Arch 兼容层！
 ```
 
-不支持 IPv6。
-
 > **注意**
 >
 > 如果以普通用户运行 QQ 时报错找不到 X11，请检查 `DISPLAY` 环境变量是否正确设置，并确保 X11 套接字（**/tmp/.X11-unix/**）对普通用户可访问。可尝试运行 `xhost +local:` 命令放宽权限。


### PR DESCRIPTION
## Summary by Sourcery

更新 Arch Linux 兼容层的文档和自动化脚本，以简化配置流程、提升稳健性，并使行为与其他 Linux 兼容章节保持一致。

增强内容：
- 修改 Arch Linux 引导（bootstrap）shell 脚本，以自动配置 Linux 仿真路径和内核版本，通过校验和（checksum）+ 重试机制验证引导文件下载，并简化初始 Arch 系统配置流程（镜像源、软件仓库、用户、sudo、locale 和密钥环）。

文档更新：
- 明确说明 Arch Linux 兼容层的配置步骤，包括内核版本配置、通过 `compat.linux.emul_path` 挂载文件系统，以及移除过期的注意事项。
- 在 Ubuntu/Debian 兼容性章节中，一致性地记录内核版本要求和服务重启要求。
- 说明 QQ Linux 客户端在 Arch 兼容层上的 IPv6 限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Arch Linux compatibility layer documentation and automation script to simplify setup, improve robustness, and align behavior with other Linux compatibility sections.

Enhancements:
- Revise the Arch Linux bootstrap shell script to automatically configure linux emulation path and kernel version, verify bootstrap downloads via checksums with retry, and streamline initial Arch system configuration (mirrors, repositories, users, sudo, locale, and keyrings).

Documentation:
- Clarify Arch Linux compatibility layer setup steps, including kernel version configuration, filesystem mounting via compat.linux.emul_path, and removal of outdated caveats.
- Document kernel version and service restart requirements consistently in the Ubuntu/Debian compatibility section.
- Note IPv6 limitations for the QQ Linux client on the Arch compatibility layer.

</details>