### PR TITLE
Update LAG configuration instructions in documentation

### DIFF
--- a/di-24-zhang-gao-ji-wang-luo/di-24.3-jie-lian-lu-ju-he-yu-gu-zhang-zhuan-yi.md
+++ b/di-24-zhang-gao-ji-wang-luo/di-24.3-jie-lian-lu-ju-he-yu-gu-zhang-zhuan-yi.md
@@ -55,6 +55,8 @@ lagg0: flags=1008843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST,LOWER_UP> metric 0 m
         nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
 ```
 
+标记为 `ACTIVE` 的端口是与远程交换机协商的 LAG 部分。流量将通过这些活动端口发送和接收。可以将 `-v` 添加到上述命令中，以查看 LAG 标识符。
+
 为使此配置在重启后仍然生效，需在 FreeBSD 系统的 **/etc/rc.conf** 文件中添加以下条目：
 
 ```sh


### PR DESCRIPTION
## Summary by Sourcery

在 FreeBSD LAG 配置文档中澄清 LAG 接口状态和标识符相关细节。

文档更新：
- 解释 LAG 输出中 ACTIVE 端口的含义，并明确说明流量会通过这些端口转发。
- 记录如何通过在状态命令中添加 `-v` 参数来显示 LAG 标识符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify LAG interface status and identifier details in the FreeBSD LAG configuration documentation.

Documentation:
- Explain the meaning of ACTIVE ports in LAG output and clarify that traffic uses these ports.
- Document how to display the LAG identifier by adding the -v flag to the status command.

</details>