### PR TITLE
Add reference to GPLinBase in FreeBSD documentation

### DIFF
--- a/di-43-zhang-freebsd-nei-he-jia-gou/di-43.1-jie-freebsd-yuan-dai-ma-mu-lu-jie-gou.md
+++ b/di-43-zhang-freebsd-nei-he-jia-gou/di-43.1-jie-freebsd-yuan-dai-ma-mu-lu-jie-gou.md
@@ -52,7 +52,6 @@ contrib 目录中包含 FreeBSD 项目集成的第三方软件，下图展示了
 │   ├── openssh/                 # OpenSSH 源代码
 │   └── openssl/                 # OpenSSL 源代码
 ├── etc/                         # /etc 模板
-├── gnu/                         # GPL 与 LGPL 许可的软件
 ├── include/                     # 系统 include 文件
 ├── kerberos5/                   # Heimdal Kerberos 5 实现
 ├── krb5/                        # MIT Kerberos 5 实现
@@ -106,7 +105,7 @@ contrib 目录中包含 FreeBSD 项目集成的第三方软件，下图展示了
 ├── fs/                          # 除 UFS、NFS、ZFS 以外的文件系统
 ├── gdb/                         # 内核远程 GDB 存根实现
 ├── geom/                        # GEOM 框架（块设备层）
-├── gnu/                         # GPL 与 LGPL 许可的软件
+├── gnu/                         # 博通网卡驱动相关
 ├── isa/                         # 工业标准结构 (ISA) 总线相关
 ├── kern/                        # 内核主要部分
 ├── kgssapi/                     # GSSAPI 相关文件


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 澄清 FreeBSD 内核源代码文档中对 gnu 目录的描述，将其改为引用与 Broadcom 网卡驱动相关的代码，而不是 GPL/LGPL 软件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify the description of the gnu directory in FreeBSD kernel source documentation to reference Broadcom NIC driver-related code instead of GPL/LGPL software.

</details>