### PR TITLE
Change GA4 update schedule to monthly

### DIFF
--- a/.github/workflows/update-ga4.yml
+++ b/.github/workflows/update-ga4.yml
@@ -2,7 +2,7 @@ name: 🔗 更新谷歌分析
 
 on:
   schedule:
-    - cron: '10 15 * * 0'  # 每周日 UTC 时间 15:10 运行
+    - cron: '10 15 1 * *'  # 每月 1 日 15:10 运行（UTC 时间）
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 将 GA4 更新工作流的 cron 触发时间从每周星期日修改为每月 1 日。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Change the GA4 update workflow cron trigger from weekly on Sundays to monthly on the 1st.

</details>