### PR TITLE
Update cron schedule for document word count workflow

### DIFF
--- a/.github/workflows/count-chinese.yml
+++ b/.github/workflows/count-chinese.yml
@@ -2,7 +2,7 @@ name: 📊 更新文档字数统计
 
 on:
   schedule:
-    - cron: '20 5 * * 0'
+    - cron: '10 20 1 * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 将字数统计工作流的 cron 表达式从每周星期日运行调整为在每个月的 1 日 20:10 运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust the cron expression for the word count workflow to run at 20:10 on the 1st of each month instead of weekly on Sundays.

</details>