### PR TITLE
Update KDE 6 Wayland startup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026 年第三季度
 
+- 2026.8.15
+  - <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=296052> 修复 KDE 6 Wayland 无法登录的 Bug 
 - 2026.7.2
   - 格式清理（空格、大小写统一、统一格式）
 

--- a/di-12-zhang-wayland-xi-tong/di-12.2-jie-wayland-xian-shi-guan-li-qi.md
+++ b/di-12-zhang-wayland-xi-tong/di-12.2-jie-wayland-xian-shi-guan-li-qi.md
@@ -2,7 +2,35 @@
 
 ## SDDM
 
-SDDM 支持 Wayland 会话，从略，参见其他有关章节。
+SDDM 基于 QML，不仅支持 X111，还支持 Wayland 会话。默认情况下左下角为 Wayland，如不是可手动修改。
+
+还需要修改配置文件 **/usr/local/etc/sddm.conf** 启用 Wayland，查找下列文字：
+
+```ini
+#[General]
+#DisplayServer=wayland
+#GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=layer-shell
+
+#[Wayland]
+#CompositorCommand=dbus-run-session ck-launch-session -- kwin_wayland --drm --no-lockscreen --no-global-shortcuts
+```
+
+将其注释全部取消掉，即为：
+
+```ini
+[General]
+DisplayServer=wayland
+GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=layer-shell
+
+[Wayland]
+CompositorCommand=dbus-run-session ck-launch-session -- kwin_wayland --drm --no-lockscreen --no-global-shortcuts
+```
+
+然后重新启用 SDDM 服务即可：
+
+```sh
+# service sddm restart
+```
 
 ## Ly
 

--- a/di-12-zhang-wayland-xi-tong/di-12.2-jie-wayland-xian-shi-guan-li-qi.md
+++ b/di-12-zhang-wayland-xi-tong/di-12.2-jie-wayland-xian-shi-guan-li-qi.md
@@ -71,4 +71,4 @@ ttyv1	"/usr/libexec/getty Pc"		xterm	onifexists secure
 ttyv1   "/usr/libexec/getty Ly"		xterm   on secure
 ```
 
-重启即可。
+重启系统即可。

--- a/di-13-zhang-zhuo-mian-huan-jing/di-13.2-jie-kde-6-zhuo-mian-huan-jing-wayland-hui-hua.md
+++ b/di-13-zhang-zhuo-mian-huan-jing/di-13.2-jie-kde-6-zhuo-mian-huan-jing-wayland-hui-hua.md
@@ -50,7 +50,7 @@ seatd 是一款 seat 管理守护进程，用于非 systemd 环境下管理 Wayl
 
 有多种方法可以启动 Wayland KDE。登录显示器建议使用 SDDM 或 Ly。
 
-使用显示管理器启动 KDE 时，在登录界面对应位置需要选择“Wayland”会话。
+使用显示管理器启动 KDE 时，在登录界面对应位置需要选择“Wayland”会话。还需参见 Wayland 登录管理器章节进行修改。
 
 ### 通过脚本启动桌面
 


### PR DESCRIPTION
Added reference to Wayland login manager modifications when starting KDE 6.

## Summary by Sourcery

文档：
- 更新 KDE 6 Wayland 启动文档，将读者引导至 Wayland 显示管理器配置部分，以进行必要的调整。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update KDE 6 Wayland startup documentation to point readers to the Wayland display manager configuration section for necessary adjustments.

</details>