### PR TITLE
Fix typo in SDDM description

### DIFF
--- a/di-12-zhang-wayland-xi-tong/di-12.2-jie-wayland-xian-shi-guan-li-qi.md
+++ b/di-12-zhang-wayland-xi-tong/di-12.2-jie-wayland-xian-shi-guan-li-qi.md
@@ -2,7 +2,7 @@
 
 ## SDDM
 
-SDDM 基于 QML，不仅支持 X111，还支持 Wayland 会话。在默认情况下，SDDM 界面左下角为 Wayland，如不是可手动修改。
+SDDM 基于 QML，不仅支持 X11，还支持 Wayland 会话。在默认情况下，SDDM 界面左下角为 Wayland，如不是可手动修改。
 
 还需要修改配置文件 **/usr/local/etc/sddm.conf** 启用 Wayland，查找下列文字：
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 修复 SDDM 文档中的一个拼写错误，将引用从 X111 更新为 X11。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix a typo in the SDDM documentation, updating the reference from X111 to X11.

</details>